### PR TITLE
ValidatingAdmissionPolicy for C-0038

### DIFF
--- a/controls/C-0038/policy.yaml
+++ b/controls/C-0038/policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0016-allow-privilege-escalation"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || ((!(has(object.spec.hostPID)) || object.spec.hostPID == false) && (!(has(object.spec.hostIPC)) || object.spec.hostIPC == false))"
+      message: "Pods with hostPID and hostIPC fields enabled may allow cross-container influence. (see more at https://hub.armosec.io/docs/c-0038)"
+
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || ((!(has(object.spec.template.spec.hostPID)) || object.spec.template.spec.hostPID == false) && (!(has(object.spec.template.spec.hostIPC)) || object.spec.template.spec.hostPID == false))"
+      message: "Workloads with hostPID and hostIPC fields enabled may allow cross-container influence. (see more at https://hub.armosec.io/docs/c-0038)"
+
+    - expression: "object.kind != 'CronJob' || ((!(has(object.spec.jobTemplate.spec.template.spec.hostPID)) || object.spec.jobTemplate.spec.template.spec.hostPID == false) && (!(has(object.spec.jobTemplate.spec.template.spec.hostIPC)) || object.spec.jobTemplate.spec.template.spec.hostIPC == false))"
+      message: "CronJob with hostPID and hostIPC fields enabled may allow cross-container influence. (see more at https://hub.armosec.io/docs/c-0038)"

--- a/controls/C-0038/tests.json
+++ b/controls/C-0038/tests.json
@@ -1,0 +1,66 @@
+[
+    {
+        "name": "Deployment with both hostIPC and hostPID set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true",
+            "spec.template.spec.hostPID=true"    
+        ]
+    },
+    {
+        "name": "Deployment with hostIPC set true and hostPID set to false is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true",
+            "spec.template.spec.hostPID=false"    
+        ]
+    },
+    {
+        "name": "Deployment with hostIPC set true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true",  
+        ]
+    },
+    {
+        "name": "Deployment without hostIPC and hostPID is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+    },
+
+
+    {
+        "name": "Pod with both hostIPC and hostPID set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostIPC=true",
+            "spec.hostPID=true"    
+        ]
+    },
+    {
+        "name": "Pod with hostIPC set true and hostPID set to false is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostIPC=true",
+            "spec.hostPID=false"  
+        ]
+    },
+    {
+        "name": "Pod with hostIPC set true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostIPC=true",
+        ]
+    },
+    {
+        "name": "Pod without hostIPC or hostPID is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+    }
+]

--- a/controls/C-0038/tests.json
+++ b/controls/C-0038/tests.json
@@ -22,13 +22,13 @@
         "template": "deployment.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.template.spec.hostIPC=true",  
+            "spec.template.spec.hostIPC=true"
         ]
     },
     {
         "name": "Deployment without hostIPC and hostPID is allowed",
         "template": "deployment.yaml",
-        "expected": "pass",
+        "expected": "pass"
     },
 
 
@@ -55,12 +55,12 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.hostIPC=true",
+            "spec.hostIPC=true"
         ]
     },
     {
         "name": "Pod without hostIPC or hostPID is allowed",
         "template": "pod.yaml",
-        "expected": "pass",
+        "expected": "pass"
     }
 ]


### PR DESCRIPTION
## Control C-0038

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### We make sure resources with `hostIPC` `OR` `hostPID` set to `true` will not be entering the cluster. 

### Control Docs: https://hub.armosec.io/docs/c-0038
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/host-pid-ipc-privileges/raw.rego