### PR TITLE
ValidatingAdmissionPolicy for C-0041

### DIFF
--- a/controls/C-0038/policy.yaml
+++ b/controls/C-0038/policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "kubescape-c-0016-allow-privilege-escalation"
+  name: "kubescape-c-0038-host-ipd-pid-previleges"
 spec:
   failurePolicy: Fail
   matchConstraints:

--- a/controls/C-0041/policy.yaml
+++ b/controls/C-0041/policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0041-host-network-access"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || !(has(object.spec.hostNetwork)) || object.spec.hostNetwork == false"
+      message: "Pods with hostNetwork enabled may cause security issues. (see more at https://hub.armosec.io/docs/c-0041)"
+
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !(has(object.spec.template.spec.hostNetwork)) || object.spec.template.spec.hostNetwork == false"
+      message: "Workloads with hostNetwork enabled may cause security issues. (see more at https://hub.armosec.io/docs/c-0041)"
+
+    - expression: "object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.template.spec.hostNetwork)) || object.spec.jobTemplate.spec.template.spec.hostNetwork == false"
+      message: "CronJob with hostNetwork enabled may cause security issues. (see more at https://hub.armosec.io/docs/c-0041)"
+
+      

--- a/controls/C-0041/tests.json
+++ b/controls/C-0041/tests.json
@@ -1,0 +1,39 @@
+[
+    {
+        "name": "Deployment with hostNetwork set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostNetwork=true"    
+        ]
+    },
+    {
+        "name": "Deployment without hostNetwork is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with hostNetwork set to false is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.hostNetwork=false"  
+        ]
+    },
+    {
+        "name": "Pod with hostNetwork set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Pod with hostNetwork set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.hostNetwork=false" 
+        ]
+    }
+]


### PR DESCRIPTION
## Control C-0041

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### We make sure resources with `hostNetwork` set to `true` will not be entering the cluster. 

### Control Docs: https://hub.armosec.io/docs/c-0041
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/host-network-access/raw.rego