### PR TITLE
ValidatingAdmissionPolicy for C-0018

### DIFF
--- a/controls/C-0001/tests.json
+++ b/controls/C-0001/tests.json
@@ -8,7 +8,7 @@
         ]
     },
     {
-        "name": "Pod without image from quay.io is blocked",
+        "name": "Pod without image from quay.io is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [

--- a/controls/C-0018/policy.yaml
+++ b/controls/C-0018/policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0018-configured-readiness-probes"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, has(container.readinessProbe))"
+      message: "Pods must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, has(container.readinessProbe))"
+      message: "Workloads must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.readinessProbe))"
+      message: "CronJob must have readinessProbe set up (see more at https://hub.armosec.io/docs/c-0018)"

--- a/controls/C-0018/tests.json
+++ b/controls/C-0018/tests.json
@@ -1,0 +1,28 @@
+[
+    {
+        "name": "Pod with readinessProbe is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].readinessProbe.httpGet.port=8080"
+        ]
+    },
+    {
+        "name": "Pod without readinessProbe is not allowed",
+        "template": "pod.yaml",
+        "expected": "fail"    
+    },
+    {
+        "name": "Deployment with readinessProbe is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].readinessProbe.httpGet.port=8080"
+        ]
+    },
+    {
+        "name": "Deployment without readinessProbe is not allowed",
+        "template": "deployment.yaml",
+        "expected": "fail"    
+    }
+]

--- a/controls/C-0044/policy.yaml
+++ b/controls/C-0044/policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0044-deny-container-with-host-port"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, !(has(container.ports)) || !(container.ports.all(port, has(port.hostPort))))"
+      message: "One or more containers in the Pod has Host-port! (see more at https://hub.armosec.io/docs/c-0044)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !(has(container.ports)) || !(container.ports.all(port, has(port.hostPort))))"
+      message: "One or more containers in the Workload has Host-port! (see more at https://hub.armosec.io/docs/c-0044)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, !(has(container.ports)) || !(container.ports.all(port, has(port.hostPort))))"
+      message: "One or more containers in the CronJob has Host-port! (see more at https://hub.armosec.io/docs/c-0044)"

--- a/controls/C-0044/tests.json
+++ b/controls/C-0044/tests.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "Pod with container having hostPort blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].ports.[0].hostPort=2023"    
+        ]
+    },
+    {
+        "name": "Pod with container not having hostPort allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment with container having hostPort blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports.[0].hostPort=2023"    
+        ]
+    },
+    {
+        "name": "Deployment with container not having hostPort allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    }
+]

--- a/test-resources/deployment.yaml
+++ b/test-resources/deployment.yaml
@@ -19,3 +19,5 @@ spec:
         image: alpine
         command: ["sh"]
         args: ["-c", "while true; do sleep 1; done"]
+        ports:
+        - containerPort: 8086

--- a/test-resources/pod.yaml
+++ b/test-resources/pod.yaml
@@ -10,3 +10,5 @@ spec:
     image: alpine
     command: ["sh"]
     args: ["-c", "while true; do sleep 1; done"]
+    ports:
+    - containerPort: 8086


### PR DESCRIPTION
## Control C-0018

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### We make sure resources with `readiness` not configured will not be entering the cluster. 

### Control Docs: https://hub.armosec.io/docs/c-0018
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/configured-readiness-probe/raw.rego