### PR TITLE
ValidatingAdmissionPolicy for C-0017

### DIFF
--- a/controls/C-0016/policy.yaml
+++ b/controls/C-0016/policy.yaml
@@ -19,9 +19,9 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, container.securityContext.allowPrivilegeEscalation == false)"
+    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation) &&  container.securityContext.allowPrivilegeEscalation == false)"
       message: "Pods with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)"
-    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, container.securityContext.allowPrivilegeEscalation == false)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation) &&  container.securityContext.allowPrivilegeEscalation == false)"
       message: "Workloads with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)"
-    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, container.securityContext.allowPrivilegeEscalation == false)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation) &&  container.securityContext.allowPrivilegeEscalation == false)"
       message: "CronJob with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)"

--- a/controls/C-0017/policy.yaml
+++ b/controls/C-0017/policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0017-deny-mutable-container-filesystem"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+      message: "Pods having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+      message: "Workloads having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+      message: "CronJob having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"

--- a/controls/C-0017/policy.yaml
+++ b/controls/C-0017/policy.yaml
@@ -19,9 +19,9 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem) &&  container.securityContext.readOnlyRootFilesystem == true)"
       message: "Pods having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"
-    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem) &&  container.securityContext.readOnlyRootFilesystem == true)"
       message: "Workloads having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"
-    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, container.securityContext.readOnlyRootFilesystem == true)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && has(container.securityContext.readOnlyRootFilesystem) &&  container.securityContext.readOnlyRootFilesystem == true)"
       message: "CronJob having containers with mutable filesystem not allowed! (see more at https://hub.armosec.io/docs/c-0017)"

--- a/controls/C-0017/tests.json
+++ b/controls/C-0017/tests.json
@@ -1,0 +1,39 @@
+[
+    {
+        "name": "Deployment with readOnlyRootFilesystem set to false is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.readOnlyRootFilesystem=false"    
+        ]
+    },
+    {
+        "name": "Deployment readOnlyRootFilesystem is not defined is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Deployment with readOnlyRootFilesystem set to true is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.readOnlyRootFilesystem=true"    
+        ]
+    },
+    {
+        "name": "Pod with readOnlyRootFilesystem set to false is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.readOnlyRootFilesystem=false"    
+        ]
+    },
+    {
+        "name": "Pod with readOnlyRootFilesystem set to true is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.readOnlyRootFilesystem=true"    
+        ]
+    }
+]


### PR DESCRIPTION
## Control C-0017

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### We make sure resources having containers with mutable filesystems will not be entering the cluster. 

### Control Docs: https://hub.armosec.io/docs/c-0017
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/immutable-container-filesystem/raw.rego