### PR TITLE
ValidatingAdmissionPolicy for C-0048

### DIFF
--- a/controls/C-0048/policy.yaml
+++ b/controls/C-0048/policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)))"
+      message: "One or more hostPath Volumes in the Pod has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
+      message: "One or more hostPath Volumes in the Workload has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
+    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.volumes.all(vol, !(has(vol.hostPath)))"
+      message: "One or more hostPath Volumes in the CronJob has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"

--- a/controls/C-0048/tests.json
+++ b/controls/C-0048/tests.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "Pod with no hostPath Volumes allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Pod with hostPath volume is denied",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes.[0].hostPath.path=/var"
+        ]
+    },
+    {
+        "name": "Deployment with no hostPath Volumes allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment with hostPath volume is denied",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes.[0].hostPath.path=/var"
+        ]
+    }
+]

--- a/test-resources/deployment.yaml
+++ b/test-resources/deployment.yaml
@@ -21,3 +21,8 @@ spec:
         args: ["-c", "while true; do sleep 1; done"]
         ports:
         - containerPort: 8086
+        volumeMounts :
+        - mountPath : /test-pd
+          name : test-volume
+      volumes :
+        - name : test-volume

--- a/test-resources/pod.yaml
+++ b/test-resources/pod.yaml
@@ -12,3 +12,9 @@ spec:
     args: ["-c", "while true; do sleep 1; done"]
     ports:
     - containerPort: 8086
+    volumeMounts :
+    - mountPath : /test-pd
+      name : test-volume
+  
+  volumes :
+  - name : test-volume


### PR DESCRIPTION
## Control C-0048

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0048
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/alert-any-hostpath/raw.rego