### PR TITLE
ValidatingAdmissionPolicy for C-0057

### DIFF
--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0057-privileged-container-denied"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container,
+        !(has(container.securityContext)) ||
+        (
+          (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+        )
+      message: "Pod has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"
+    - expression: > 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
+        !(has(container.securityContext)) ||
+        (
+          (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+        )
+      message: "Workloads has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"
+    - expression: >
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
+        !(has(container.securityContext)) ||
+        (
+          (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+        )
+      message: "CronJob has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"

--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -1,0 +1,47 @@
+[
+    {
+        "name": "Pod having container having securityContext.privileged set to true is denied",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Pod having container with \"SYS_ADM\" capability is denied",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Pod having container having securityContext.privileged set to true and with \"SYS_ADM\" capability is denied",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Pod having container not having securityContext.privileged set to true and without \"SYS_ADM\" capability is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment having container having securityContext.privileged set to true and with \"SYS_ADM\" capability is denied",
+        "template": "deployment-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Deployment having container not having securityContext.privileged set to true and without \"SYS_ADM\" capability is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    }
+]

--- a/test-resources/deployment-for-list-items.yaml
+++ b/test-resources/deployment-for-list-items.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  labels:
+    admission-policy-test: abc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-deployment
+  template:
+    metadata:
+      labels:
+        app: test-deployment
+    spec:
+      containers:
+      - name: sleep
+        image: alpine
+        command: ["sh"]
+        args: ["-c", "while true; do sleep 1; done"]
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADM

--- a/test-resources/pod-for-list-items.yaml
+++ b/test-resources/pod-for-list-items.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    admission-policy-test: abc
+spec:
+  containers:
+  - name: sleep
+    image: alpine
+    command: ["sh"]
+    args: ["-c", "while true; do sleep 1; done"]
+    securityContext:
+      capabilities:
+        add:
+        - SYS_ADM


### PR DESCRIPTION
## Control C-0057

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0057
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/rule-privileged-container/raw.rego