### PR TITLE
ValidatingAdmissionPolicy for  C-0061

### DIFF
--- a/controls/C-0061/policy.yaml
+++ b/controls/C-0061/policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0061-deny-workloads-in-default-namespace"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: "['Pod','Deployment','ReplicaSet','DaemonSet','StatefulSet','Job', 'CronJob'].all(kind, object.kind != kind) || (has(object.metadata.namespace) && object.metadata.namespace != 'default')"
+      message: "Workloads with privileged containers are not allowed! (see more at https://hub.armosec.io/docs/c-0016)"

--- a/controls/C-0061/tests.json
+++ b/controls/C-0061/tests.json
@@ -1,0 +1,48 @@
+[
+    {
+        "name": "Pod with namespace not set is denied",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Pod with namespace set to default is denied",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Pod with namespace set to value other than default is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "Deployment with namespace not set is denied",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment with namespace set to default is denied",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Deployment with namespace set to value other than default is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    }
+]

--- a/scripts/run-control-tests.py
+++ b/scripts/run-control-tests.py
@@ -29,6 +29,9 @@ if not os.path.exists(TEST_RESOURCES_DIR):
 with open('tests.json', 'r') as f:
     tests = json.load(f)
 
+# Create a test namespace
+subprocess.check_call(['kubectl', 'create', 'namespace','test-namespace'])
+
 # Apply the configuraton CRD
 subprocess.check_call(['kubectl', 'apply', '-f', os.path.join(CONFIGURATION_DIR, 'policy-configuration-definition.yaml')])
 
@@ -102,7 +105,7 @@ for test in tests:
         print(colored('Test passed!','green'))
    
     print(colored('Cleaning up...', 'yellow'))
-    # Run kubectl delete on the policy and policy binding
+    # Run kubectl delete on the policy and policy binding.
     try:
         subprocess.check_call(['kubectl', 'delete', '-f', 'policy.yaml'],stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.check_call(['kubectl', 'delete', '-f', policy_bind_temp_file_name],stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -127,7 +130,10 @@ for test in tests:
     print('-'*120)
     print('')
     
-    
+
+# Delete the test namespace
+subprocess.check_call(['kubectl', 'delete', 'namespaces', 'test-namespace'],stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  
+
 if all_tests_passed:
     print(colored('Control tests passed!','green'))
     sys.exit(0)


### PR DESCRIPTION
## Control C-0061

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0061
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/pods-in-default-namespace/raw.rego