### PR TITLE
ValidatingAdmissionPolicy for C-0076

### DIFF
--- a/controls/C-0076/policy.yaml
+++ b/controls/C-0076/policy.yaml
@@ -1,0 +1,63 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: > 
+        object.kind != 'Pod' ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.recommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+      message: "Pods doesn't have any label from the configured list! (see more at https://hub.armosec.io/docs/c-0076)"
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.recommendedLabels.all(
+            labelInList, labelInList != label
+          ))) &&
+          has(object.spec.template.metadata) &&
+          has(object.spec.template.metadata.labels) &&
+          !(object.spec.template.metadata.labels.all(label, params.settings.recommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+
+      message: "Workload or Pod in workload doesn't have any label from the configured list! (see more at https://hub.armosec.io/docs/c-0076)"
+    - expression: >
+        object.kind != 'CronJob' ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.recommendedLabels.all(
+            labelInList, labelInList != label
+          ))) &&
+          has(object.spec.jobTemplate.metadata) &&
+          has(object.spec.jobTemplate.metadata.labels) &&
+          !(object.spec.jobTemplate.metadata.labels.all(label, params.settings.recommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+
+      message: "CronJob or Pod in CronJob doesn't have any label from the configured list! (see more at https://hub.armosec.io/docs/c-0076)"

--- a/controls/C-0076/tests.json
+++ b/controls/C-0076/tests.json
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "Pod without lables from the configured list is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [   
+        ]
+    },
+    {
+        "name": "Pod with label app is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.labels.app=label-test"
+        ]
+    },
+    {
+        "name": "Pod with label app and env is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.labels.app=label-test",
+            "metadata.labels.env=label-test"
+        ]
+    },
+    {
+        "name": "Deployment and its PodSpec without lables from the configured list is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [   
+        ]
+    },
+    {
+        "name": "Deployment with label \"tier\" and PodSpec without lables from the configured list is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.labels.tier=label-test"
+        ]
+    },
+    {
+        "name": "Deployment with label \"tier\" and PodSpec with label \"app\" is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.labels.tier=label-test",
+            "spec.template.metadata.labels.app=label-test"
+        ]
+    },
+    {
+        "name": "Deployment without lables from the configured list and PodSpec with \"app\" label is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.labels.tier=label-test"
+        ]
+    }
+]

--- a/test-resources/deployment.yaml
+++ b/test-resources/deployment.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-deployment
+      label: test-deployment
   template:
     metadata:
       labels:
-        app: test-deployment
+        label: test-deployment
     spec:
       containers:
       - name: sleep


### PR DESCRIPTION
## Control C-0076

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0076
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/label-usage-for-resources/raw.rego