### PR TITLE
ValidatingAdmissionPolicy for  C-0077

### DIFF
--- a/controls/C-0077/policy.yaml
+++ b/controls/C-0077/policy.yaml
@@ -1,0 +1,61 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: > 
+        object.kind != 'Pod' ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.k8sRecommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+      message: "Pod doesn't have any k8s common label from the configured list! (see more at https://hub.armosec.io/docs/c-0077)"
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.k8sRecommendedLabels.all(
+            labelInList, labelInList != label
+          ))) &&
+          has(object.spec.template.metadata) &&
+          has(object.spec.template.metadata.labels) &&
+          !(object.spec.template.metadata.labels.all(label, params.settings.k8sRecommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+      message: "Workload or Pod in workload doesn't have any k8s common label from the configured list! (see more at https://hub.armosec.io/docs/c-0077)"
+    - expression: >
+        object.kind != 'CronJob' ||
+        (
+          has(object.metadata.labels) &&
+          !(object.metadata.labels.all(label, params.settings.k8sRecommendedLabels.all(
+            labelInList, labelInList != label
+          ))) &&
+          has(object.spec.jobTemplate.metadata) &&
+          has(object.spec.jobTemplate.metadata.labels) &&
+          !(object.spec.jobTemplate.metadata.labels.all(label, params.settings.k8sRecommendedLabels.all(
+            labelInList, labelInList != label
+          )))
+        )
+      message: "CronJob or Pod in workload doesn't have any k8s common label from the configured list! (see more at https://hub.armosec.io/docs/c-0077)"

--- a/controls/C-0077/tests.json
+++ b/controls/C-0077/tests.json
@@ -1,0 +1,45 @@
+[
+    {
+        "name": "Pod without one of configured common labels is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [  
+        ]
+    },
+    {
+        "name": "Pod with label \"app.kubernetes.io/name\" is allowed",
+        "template": "pod-for-list-items.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment and its PodSpec without one of configured common labels is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [  
+        ]
+    },
+    {
+        "name": "Deployment with label \"app.kubernetes.io/name\" and its PodSpec without one of configured common labels is blocked",
+        "template": "deployment-with-common-label-1.yaml",
+        "expected": "fail",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment without one of configured common labels and its PodSpec with label \"app.kubernetes.io/name\" is blocked",
+        "template": "deployment-with-common-label-2.yaml",
+        "expected": "fail",
+        "field_change_list": [  
+        ]
+    },
+    {
+        "name": "Deployment and PodSpec with label \"app.kubernetes.io/name\" is allowed",
+        "template": "deployment-for-list-items.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    }
+
+]

--- a/test-resources/deployment-with-common-label-1.yaml
+++ b/test-resources/deployment-with-common-label-1.yaml
@@ -14,7 +14,6 @@ spec:
     metadata:
       labels:
         app: test-deployment
-        app.kubernetes.io/name: myApp
     spec:
       containers:
       - name: sleep

--- a/test-resources/deployment-with-common-label-2.yaml
+++ b/test-resources/deployment-with-common-label-2.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test-deployment
   labels:
     admission-policy-test: abc
-    app.kubernetes.io/name: myApp
 spec:
   replicas: 1
   selector:

--- a/test-resources/pod-for-list-items.yaml
+++ b/test-resources/pod-for-list-items.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-pod
   labels:
     admission-policy-test: abc
+    app.kubernetes.io/name: myApp
 spec:
   containers:
   - name: sleep


### PR DESCRIPTION
## Control C-0077

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0077
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/K8s%20common%20labels%20usage/raw.rego