### PR TITLE
ValidatingAdmissionPolicy for  C-0078

### DIFF
--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0078-only-allow-images-from-allowed-registry"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || 
+        object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
+        (
+          (registry == 'docker.io' && !container.image.contains('/')) ||
+          (container.image.startsWith(registry))
+        )))
+      message: "Pods uses an image from a registry that is not in the allow list! (see more at https://hub.armosec.io/docs/c-0078)"
+    - expression: > 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
+        object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
+        (
+          (registry == 'docker.io' && !container.image.contains('/')) ||
+          (container.image.startsWith(registry))
+        )))
+      message: "Workloads uses an image from a registry that is not in the allow list! (see more at https://hub.armosec.io/docs/c-0078)"
+    - expression: >
+        object.kind != 'CronJob' ||
+        object.spec.jobTemplate.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
+        (
+          (registry == 'docker.io' && !container.image.contains('/')) ||
+          (container.image.startsWith(registry))
+        )))
+      message: "CronJob uses an image from a registry that is not in the allow list! (see more at https://hub.armosec.io/docs/c-0078)"

--- a/controls/C-0078/tests.json
+++ b/controls/C-0078/tests.json
@@ -1,0 +1,64 @@
+[
+    {
+        "name": "Pod with image from quay.io is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=quay.io/openshift/origin-cli:latest"    
+        ]
+    },
+    {
+        "name": "Pod with image from gcr.io is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].image=gcr.io/google-containers/busybox"
+        ]
+    },
+    {
+        "name": "Pod with image from docker.io without prefix docker.io/ is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Pod with image from docker.io with prefix docker.io/ is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].image=docker.io/alpine"
+        ]
+    },
+    {
+        "name": "Deployment with image from quay.io is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=quay.io/openshift/origin-cli:latest"    
+        ]
+    },
+    {
+        "name": "Deployment with image from gcr.io is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=gcr.io/google-containers/busybox"
+        ]
+    },
+    {
+        "name": "Deployment with image from docker.io without prefix docker.io/ is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Deployment with image from docker.io with prefix docker.io/ is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=docker.io/alpine"
+        ]
+    }
+]

--- a/test-resources/default-control-configuration.yaml
+++ b/test-resources/default-control-configuration.yaml
@@ -9,6 +9,7 @@ settings:
   cpuRequestMin: 0.1
   imageRepositoryAllowList:
   - gcr.io
+  - docker.io # Not in Kubescape's initial configuration but added to test as this is an edge case.
   insecureCapabilities:
   - SETPCAP
   - NET_ADMIN


### PR DESCRIPTION
## Control C-0078

### Related Resources: CronJob, DaemonSet, Deployment, Job, Pod, ReplicaSet, StatefulSet

### Control Docs: https://hub.armosec.io/docs/c-0078
### Control Rego: https://github.com/kubescape/regolibrary/blob/master/rules/container-image-repository/raw.rego