### PR TITLE
Bumping policies to beta 1 API version in 1.28

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,12 +20,12 @@ jobs:
       uses: slashben/setup-minikube@master
       with:
           feature-gates: 'ValidatingAdmissionPolicy=true'
-          extra-config: 'apiserver.runtime-config=admissionregistration.k8s.io/v1alpha1'
-          kubernetes-version: 1.27.0
+          extra-config: 'apiserver.runtime-config=admissionregistration.k8s.io/v1beta1'
+          kubernetes-version: v1.28.0-rc.1
           container-runtime: containerd
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10' 
+        python-version: '3.10'
     - uses: azure/setup-kubectl@v3
     - name: Running all control policy tests
       run: |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Kubescape Validating Admission Policy library
 
-This is a library of policies based on [Kubescape controls](https://hub.armosec.io/docs/controls) ready for use with [Kubernetes Validating Admission Policies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/). In this library, Kubescape controls have been re-implemented in [CEL](https://github.com/google/cel-spec/) for your convenience. 
+This is a library of policies based on [Kubescape controls](https://hub.armosec.io/docs/controls) ready for use with [Kubernetes Validating Admission Policies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/). In this library, Kubescape controls have been re-implemented in [CEL](https://github.com/google/cel-spec/) for your convenience.
 
 ## Using the library
 
-*Note: Kubernetes Validating Admission Policy feature _is _still in _its_ early phase_. 
-It has been released as an alphav1 feature in Kubernetes 1.26,
+*Note: Kubernetes Validating Admission Policy feature _is _still in _its_ early phase_.
+It has been released as an betav1 feature in Kubernetes 1.28,
 and you need to enable its feature gate to be able to use it. Therefore it is not yet production ready. Look [here](docs/validating-admission-policies/README.md) for _how to _set up_ a playground_.*
 
 
@@ -26,7 +26,7 @@ You can apply policies to objects, for example, to apply control [C-0016](https:
 ```bash
 # Creating a binding
 kubectl apply -f - <<EOT
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0016-binding

--- a/controls/C-0001/policy.yaml
+++ b/controls/C-0001/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0001-deny-forbidden-container-registries"

--- a/controls/C-0004/policy.yaml
+++ b/controls/C-0004/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0004-deny-resources-with-memory-limit-or-request-not-set"
@@ -26,8 +26,8 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
-        object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && 
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
         params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
         params.settings.memoryRequestMax >= int(container.resources.requests.memory)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
@@ -36,7 +36,7 @@ spec:
       message: "Pods contains container/s with memory limit or request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0004)"
 
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
         params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
         params.settings.memoryRequestMax >= int(container.resources.requests.memory)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
@@ -45,7 +45,7 @@ spec:
       message: "Workloads contains container/s with memory limit or request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0004)"
 
     - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) && 
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
         params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
         params.settings.memoryRequestMax >= int(container.resources.requests.memory)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&

--- a/controls/C-0009/policy.yaml
+++ b/controls/C-0009/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0009-deny-resources-with-memory-or-cpu-limit-not-set"
@@ -26,7 +26,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container,
         has(container.resources) &&
         has(container.resources.limits) &&

--- a/controls/C-0016/policy.yaml
+++ b/controls/C-0016/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0016-allow-privilege-escalation"

--- a/controls/C-0017/policy.yaml
+++ b/controls/C-0017/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0017-deny-resources-with-mutable-container-filesystem"

--- a/controls/C-0018/policy.yaml
+++ b/controls/C-0018/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0018-deny-resources-without-configured-readiness-probes"

--- a/controls/C-0020/policy.yaml
+++ b/controls/C-0020/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials"
@@ -26,8 +26,8 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
-        object.kind != 'Pod' || !has(object.spec.volumes) || object.spec.volumes.all(vol, 
+    - expression: >
+        object.kind != 'Pod' || !has(object.spec.volumes) || object.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
           (params.settings.cloudProvider != 'eks' ||
@@ -41,7 +41,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
@@ -53,7 +53,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (
@@ -69,7 +69,7 @@ spec:
       message: "Pod contains volumes with potential access to known cloud credentials! (see more at https://hub.armosec.io/docs/c-0020)"
 
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol, 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
           (params.settings.cloudProvider != 'eks' ||
@@ -83,7 +83,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
@@ -95,7 +95,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (
@@ -111,7 +111,7 @@ spec:
       message: "Workload contains volumes with potential access to known cloud credentials! (see more at https://hub.armosec.io/docs/c-0020)"
 
     - expression: >
-        object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes) || object.spec.jobTemplate.spec.volumes.all(vol, 
+        object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes) || object.spec.jobTemplate.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
           (params.settings.cloudProvider != 'eks' ||
@@ -125,7 +125,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
@@ -137,7 +137,7 @@ spec:
             (
               unsafePath != vol.hostPath.path
             )))) &&
-          
+
           (params.settings.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (

--- a/controls/C-0034/policy.yaml
+++ b/controls/C-0034/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled"
@@ -23,7 +23,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'ServiceAccount' ||
         (
           has(object.automountServiceAccountToken) &&
@@ -31,7 +31,7 @@ spec:
         )
       message: "ServiceAccount has \"automountServiceAccountToken\" enabled! (see more at https://hub.armosec.io/docs/c-0034)"
 
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' ||
         (
           has(object.spec.automountServiceAccountToken) &&

--- a/controls/C-0038/policy.yaml
+++ b/controls/C-0038/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0038-deny-resources-with-host-ipc-or-pid-privileges"

--- a/controls/C-0041/policy.yaml
+++ b/controls/C-0041/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0041-deny-resources-with-host-network-access"
@@ -32,4 +32,3 @@ spec:
     - expression: "object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.template.spec.hostNetwork)) || object.spec.jobTemplate.spec.template.spec.hostNetwork == false"
       message: "CronJob with hostNetwork enabled may cause security issues. (see more at https://hub.armosec.io/docs/c-0041)"
 
-      

--- a/controls/C-0042/policy.yaml
+++ b/controls/C-0042/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0042-deny-resources-with-ssh-server-running"
@@ -23,12 +23,12 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: >  
+    - expression: >
         object.kind != 'Service' ||
         object.spec.ports.all(currentPort, currentPort.port != 22 && currentPort.port != 2222 && currentPort.targetPort != 22 && currentPort.targetPort != 2222)
       message: "Services with ssh server(Port 22 and 2222) are denied! (see more at https://hub.armosec.io/docs/c-0042)"
     - expression: >
-        object.kind != 'Pod' || 
+        object.kind != 'Pod' ||
         object.spec.containers.all(container, !has(container.ports) || container.ports.all(port,
         ((
         !has(port.containerPort) ||
@@ -57,7 +57,7 @@ spec:
           port.hostPort != 2222
         )))))
       message: "Workloads having containers running ssh server are not allowed! (see more at https://hub.armosec.io/docs/c-0042)"
-    - expression: > 
+    - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !has(container.ports) || container.ports.all(port,
         ((
         !has(port.containerPort) ||

--- a/controls/C-0044/policy.yaml
+++ b/controls/C-0044/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0044-deny-resources-with-host-port"

--- a/controls/C-0045/policy.yaml
+++ b/controls/C-0045/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false"
@@ -23,21 +23,21 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||
           (has(containerVol.readOnly) && containerVol.readOnly == true)
         )))
       message: "One or more hostPath Volumes in the Pod has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
-    - expression: > 
+    - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||
           (has(containerVol.readOnly) && containerVol.readOnly == true)
         )))
       message: "One or more hostPath Volumes in the Workload has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
-    - expression: > 
+    - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.jobTemplate.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||

--- a/controls/C-0046/policy.yaml
+++ b/controls/C-0046/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0046-deny-resources-with-insecure-capabilities"
@@ -27,7 +27,7 @@ spec:
       resources:   ["jobs","cronjobs"]
   validations:
     - expression: >
-        object.kind != 'Pod' || 
+        object.kind != 'Pod' ||
         object.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
         container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
@@ -41,7 +41,7 @@ spec:
         ))
       message: "Workload has one or more containers with insecure capabilities! (see more at https://hub.armosec.io/docs/c-0046)"
     - expression: >
-        object.kind != 'CronJob' || 
+        object.kind != 'CronJob' ||
         object.spec.jobTemplate.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
         container.securityContext.capabilities.add.all(capability, capability != insecureCapability)

--- a/controls/C-0048/policy.yaml
+++ b/controls/C-0048/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0048-deny-workloads-with-hostpath-mounts"

--- a/controls/C-0050/policy.yaml
+++ b/controls/C-0050/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0050-deny-resources-with-cpu-limit-or-request-not-set"
@@ -26,8 +26,8 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
-        object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && 
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
@@ -36,7 +36,7 @@ spec:
       message: "Pods contains container/s with cpu limit or request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0050)"
 
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
@@ -45,7 +45,7 @@ spec:
       message: "Workloads contains container/s with cpu limit or request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0050)"
 
     - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) && 
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&

--- a/controls/C-0055/policy.yaml
+++ b/controls/C-0055/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0055-linux-hardening"
@@ -23,11 +23,11 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' ||
         (has(object.metadata.annotations) && object.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
         (has(object.spec.securityContext) && (has(object.spec.securityContext.seccompProfile) || has(object.spec.securityContext.seLinuxOptions))) ||
-        object.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || 
+        object.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||
         (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
       message: "Pods could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)"
@@ -35,7 +35,7 @@ spec:
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
         (has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
         (has(object.spec.template.spec.securityContext) && (has(object.spec.template.spec.securityContext.seccompProfile) || has(object.spec.template.spec.securityContext.seLinuxOptions))) ||
-        object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || 
+        object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||
         (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
       message: "Workloads could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)"
@@ -43,7 +43,7 @@ spec:
         object.kind != 'CronJob' ||
         (has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
         (has(object.spec.jobTemplate.spec.securityContext) && (has(object.spec.jobTemplate.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.securityContext.seLinuxOptions))) ||
-        object.spec.jobTemplate.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) || 
+        object.spec.jobTemplate.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||
         (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))
       message: "CronJob could have more security hardening! (see more at https://hub.armosec.io/docs/c-0055)"

--- a/controls/C-0056/policy.yaml
+++ b/controls/C-0056/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0056-deny-resources-without-configured-liveliness-probes"

--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0057-privileged-container-denied"
@@ -28,16 +28,16 @@ spec:
         !(has(container.securityContext)) ||
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
-          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
           container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
         )
       message: "Pod has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"
-    - expression: > 
+    - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
         !(has(container.securityContext)) ||
         (
           (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
-          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
           container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
         )
       message: "Workloads has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"
@@ -46,7 +46,7 @@ spec:
         !(has(container.securityContext)) ||
         (
           (!(has(container.securityContext.priviliged)) || container.securityContext.privileged != true) &&
-          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) || 
+          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
           container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
         )
       message: "CronJob has one or more privileged container.(see more at https://hub.armosec.io/docs/c-0057)"

--- a/controls/C-0061/policy.yaml
+++ b/controls/C-0061/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0061-deny-workloads-in-default-namespace"

--- a/controls/C-0062/policy.yaml
+++ b/controls/C-0062/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint"

--- a/controls/C-0073/policy.yaml
+++ b/controls/C-0073/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0073-deny-naked-pods"

--- a/controls/C-0074/policy.yaml
+++ b/controls/C-0074/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0074-resources-mounting-docker-socket-denied"
@@ -24,8 +24,8 @@ spec:
       resources:   ["jobs","cronjobs"]
   validations:
     - expression: >
-        object.kind != 'Pod' || !(has(object.spec.volumes)) || 
-        object.spec.volumes.all(vol, !(has(vol.hostPath)) || 
+        object.kind != 'Pod' || !(has(object.spec.volumes)) ||
+        object.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         !(has(vol.hostPath.path)) ||
         (
           vol.hostPath.path != '/var/run/docker.sock' &&
@@ -33,8 +33,8 @@ spec:
         ))
       message: "Pod has one or more containers mounting Docker socket! (see more at https://hub.armosec.io/docs/c-0074)"
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || !(has(object.spec.template.spec.volumes)) || 
-        object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) || 
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || !(has(object.spec.template.spec.volumes)) ||
+        object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         !(has(vol.hostPath.path)) ||
         (
           vol.hostPath.path != '/var/run/docker.sock' &&
@@ -42,8 +42,8 @@ spec:
         ))
       message: "Workload has one or more containers mounting Docker socket! (see more at https://hub.armosec.io/docs/c-0074)"
     - expression: >
-        object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.volumes)) || 
-        object.spec.jobTemplate.spec.volumes.all(vol, !(has(vol.hostPath)) || 
+        object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.volumes)) ||
+        object.spec.jobTemplate.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         !(has(vol.hostPath.path)) ||
         (
           vol.hostPath.path != '/var/run/docker.sock' &&

--- a/controls/C-0075/policy.yaml
+++ b/controls/C-0075/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0075-deny-resources-with-image-pull-policy-not-set-to-always-for-latest-tag"
@@ -23,7 +23,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container,
         !(
           container.image.findAll(":[\\w][\\w.-]{0,127}(\\/)?").all(substring, substring.endsWith("/")) ||

--- a/controls/C-0076/policy.yaml
+++ b/controls/C-0076/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set"
@@ -26,7 +26,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' ||
         (
           has(object.metadata.labels) &&

--- a/controls/C-0077/policy.yaml
+++ b/controls/C-0077/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set"
@@ -26,7 +26,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
   validations:
-    - expression: > 
+    - expression: >
         object.kind != 'Pod' ||
         (
           has(object.metadata.labels) &&

--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0078-only-allow-images-from-allowed-registry"
@@ -27,14 +27,14 @@ spec:
       resources:   ["jobs","cronjobs"]
   validations:
     - expression: >
-        object.kind != 'Pod' || 
+        object.kind != 'Pod' ||
         object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
           (registry == 'docker.io' && !container.image.contains('/')) ||
           (container.image.startsWith(registry))
         )))
       message: "Pods uses an image from a registry that is not in the allow list! (see more at https://hub.armosec.io/docs/c-0078)"
-    - expression: > 
+    - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
         object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (

--- a/docs/validating-admission-policies/README.md
+++ b/docs/validating-admission-policies/README.md
@@ -29,7 +29,7 @@ kubectl label namespace vap-playground vap=enabled
 
 Here is an example policy for denying Pods without `app` label:
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: deny-pods-without-app-label
@@ -45,7 +45,7 @@ spec:
     - expression: "has(object.metadata.labels) && has(object.metadata.labels.app)"
       message: "Pods must have app label!"
 ```
-Note the `matchConstraints`. This definition means that this policy is only applicable to Pod objects. The `validation` part contains the CEL expression which is a boolean query on the object which is subject of this admission policy. 
+Note the `matchConstraints`. This definition means that this policy is only applicable to Pod objects. The `validation` part contains the CEL expression which is a boolean query on the object which is subject of this admission policy.
 
 You can apply this directly with:
 ```bash
@@ -55,7 +55,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubescape/cel-admission-libra
 In order to apply this policy on a namespace, you have to create a binding. Here is a binding to namespaces with the label `vap: enabled`
 
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: deny-pods-without-app-label-binding
@@ -74,7 +74,7 @@ You can apply this directly with:
 kubectl apply -f https://raw.githubusercontent.com/kubescape/cel-admission-library/main/docs/validating-admission-policies/deny-pods-without-app-label-policy-binding.yaml
 ```
 
-If you now trying to create a pod inside this namespace without a label, you should be denied. 
+If you now trying to create a pod inside this namespace without a label, you should be denied.
 
 Check this out:
 ```bash
@@ -85,7 +85,7 @@ It should be denied with:
 The pods "nginx" is invalid: : ValidatingAdmissionPolicy 'deny-pods-without-app-label' with binding 'deny-pods-without-app-label-binding' denied request: Pods must have app label!
 ```
 
-On the other hand, if you create it with `app` label 
+On the other hand, if you create it with `app` label
 ```
 kubectl -n vap-playground  run nginx --image=nginx --labels="app=nginx"
 ```

--- a/docs/validating-admission-policies/deny-pods-without-app-label-policy-binding.yaml
+++ b/docs/validating-admission-policies/deny-pods-without-app-label-policy-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: deny-pods-without-app-label-binding

--- a/docs/validating-admission-policies/deny-pods-without-app-label-policy.yaml
+++ b/docs/validating-admission-policies/deny-pods-without-app-label-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: deny-pods-without-app-label

--- a/scripts/setup-test-minikube-cluster.sh
+++ b/scripts/setup-test-minikube-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Setup a Kubernetes cluster with Kyverno and a signed image policy for the attack POC
-# Usage: setup-cluster.sh 
+# Usage: setup-cluster.sh
 
 # Check if minikube is available
 if ! command -v minikube &> /dev/null
@@ -21,5 +21,4 @@ if minikube status | grep -q "host: Running"; then
     exit
 fi
 
-minikube start --driver=docker --kubernetes-version=1.27.0 --extra-config=apiserver.runtime-config=admissionregistration.k8s.io/v1alpha1  --feature-gates='ValidatingAdmissionPolicy=true' --container-runtime=containerd || exit 1
-
+minikube start --driver=docker --kubernetes-version=v1.28.0-rc.1 --extra-config=apiserver.runtime-config=admissionregistration.k8s.io/v1beta1 --feature-gates='ValidatingAdmissionPolicy=true' || exit 1

--- a/test-resources/policy-binding.yaml
+++ b/test-resources/policy-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: placeholder
@@ -7,6 +7,7 @@ spec:
   validationActions: [Deny]
   paramRef:
     name: placeholder
+    parameterNotFoundAction: Deny
   matchResources:
     objectSelector:
       matchLabels:


### PR DESCRIPTION
Validating Admission Policies are moving to beta in Kubernetes 1.28 and we need to progress 😉 