### PR TITLE
fix: test directory path was missing the dir prefix

### DIFF
--- a/scripts/run-all-control-tests.sh
+++ b/scripts/run-all-control-tests.sh
@@ -29,7 +29,7 @@ fi
 result=0
 # Run all control tests
 for control in $(ls controls); do
-    if [[ -d $control ]]; then
+    if [[ -d controls/$control ]]; then
         echo "=================================================="
         echo "Running test $control"
         echo "--------------------------------------------------"


### PR DESCRIPTION
You can see from the Actions output that no test is being executed since adding the bogus if directory check:
Compare the "Running all control policy tests" section of the latest:
https://github.com/kubescape/cel-admission-library/actions/runs/6380302477/job/17314432072
and the last "real" run:
https://github.com/kubescape/cel-admission-library/actions/runs/6239124590/job/16936381023