### PR TITLE
Aligning the library with v1 release of VAP

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,9 +19,7 @@ jobs:
       id: minikube
       uses: slashben/setup-minikube@master
       with:
-          feature-gates: 'ValidatingAdmissionPolicy=true'
-          extra-config: 'apiserver.runtime-config=admissionregistration.k8s.io/v1beta1'
-          kubernetes-version: v1.28.0-rc.1
+          kubernetes-version: v1.30.0
           container-runtime: containerd
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,30 +7,6 @@ on:
       - "v*"
 
 jobs:
-
-  test-all-policies:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: start minikube
-      id: minikube
-      uses: slashben/setup-minikube@master
-      with:
-          feature-gates: 'ValidatingAdmissionPolicy=true'
-          extra-config: 'apiserver.runtime-config=admissionregistration.k8s.io/v1beta1'
-          kubernetes-version: v1.28.0-rc.1
-          container-runtime: containerd
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - uses: azure/setup-kubectl@v3
-    - name: Running all control policy tests
-      run: |
-        kubectl version
-        pip install --upgrade pip
-        pip install -r requirements.txt
-        ./scripts/run-all-control-tests.sh
-
   release:
     needs: test-all-policies
     runs-on: ubuntu-latest
@@ -49,11 +25,12 @@ jobs:
       - name: Create release artifacts
         run: |
           mkdir release
+          kubectl kustomize apis/k8s-v1/ > release/kubescape-validating-admission-policies-v1.yaml
           kubectl kustomize apis/k8s-v1beta1/ > release/kubescape-validating-admission-policies-v1beta1.yaml
           kubectl kustomize apis/x-k8s-v1alpha1/ > release/kubescape-validating-admission-policies-x-v1alpha1.yaml
           kubectl kustomize apis/k8s-v1alpha1/ > release/kubescape-validating-admission-policies-v1alpha1.yaml
-          # Making a copy of the v1beta1 file to be used as the default policy release artifact
-          cp release/kubescape-validating-admission-policies-v1beta1.yaml release/kubescape-validating-admission-policies.yaml
+          # Making a copy of the v1 file to be used as the default policy release artifact
+          cp release/kubescape-validating-admission-policies-v1.yaml release/kubescape-validating-admission-policies.yaml
 
       - name: Create a GitHub release
         uses: softprops/action-gh-release@v1
@@ -61,6 +38,7 @@ jobs:
         with:
           files: |
             release/kubescape-validating-admission-policies.yaml
+            release/kubescape-validating-admission-policies-v1.yaml
             release/kubescape-validating-admission-policies-v1beta1.yaml
             release/kubescape-validating-admission-policies-x-v1alpha1.yaml
             release/kubescape-validating-admission-policies-v1alpha1.yaml

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ This is a library of policies based on [Kubescape controls](https://hub.armosec.
 
 ## Using the library
 
-*Note: Kubernetes Validating Admission Policy feature _is _still in _its_ early phase_.
-It has been released as an betav1 feature in Kubernetes 1.28,
-and you need to enable its feature gate to be able to use it. Therefore it is not yet production ready. Look [here](docs/validating-admission-policies/README.md) for _how to _set up_ a playground_.*
+Kubernetes Validating Admission Policy (or *VAP*) feature was released as a GA feature in version 1.30 and it is a releatively new feature (this library supports alpha and beta versions as well). Before you start playing with it, make sure you have a cluster that supports this feature. Look [here](docs/validating-admission-policies/README.md) for _how to _set up_ a playground_.*
 
 
-Install latest the release of the library:
+Install latest the release of the library (`v1` version of *VAP*):
 ```bash
 # Install configuration CRD
 kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/latest/download/policy-configuration-definition.yaml
@@ -26,7 +24,7 @@ You can apply policies to objects, for example, to apply control [C-0016](https:
 ```bash
 # Creating a binding
 kubectl apply -f - <<EOT
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0016-binding

--- a/apis/k8s-v1/kustomization.yaml
+++ b/apis/k8s-v1/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+- ../../controls
+- ../../runtime-policies
+patches:
+  - target:
+      group: admissionregistration.k8s.io
+      version: v1beta1
+      kind: ValidatingAdmissionPolicy
+      name: ""
+    path: patch.json

--- a/apis/k8s-v1/patch.json
+++ b/apis/k8s-v1/patch.json
@@ -1,0 +1,7 @@
+[
+    {
+      "op": "replace",
+      "path": "/apiVersion",
+      "value": "admissionregistration.k8s.io/v1"
+    }
+]

--- a/controls/C-0001/policy.yaml
+++ b/controls/C-0001/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0001-deny-forbidden-container-registries"

--- a/controls/C-0004/policy.yaml
+++ b/controls/C-0004/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0004-deny-resources-with-memory-limit-or-request-not-set"

--- a/controls/C-0009/policy.yaml
+++ b/controls/C-0009/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0009-deny-resources-with-memory-or-cpu-limit-not-set"

--- a/controls/C-0016/policy.yaml
+++ b/controls/C-0016/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0016-allow-privilege-escalation"

--- a/controls/C-0017/policy.yaml
+++ b/controls/C-0017/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0017-deny-resources-with-mutable-container-filesystem"

--- a/controls/C-0018/policy.yaml
+++ b/controls/C-0018/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0018-deny-resources-without-configured-readiness-probes"

--- a/controls/C-0020/policy.yaml
+++ b/controls/C-0020/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0020-deny-resources-having-volumes-with-potential-access-to-known-cloud-credentials"

--- a/controls/C-0034/policy.yaml
+++ b/controls/C-0034/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled"

--- a/controls/C-0038/policy.yaml
+++ b/controls/C-0038/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0038-deny-resources-with-host-ipc-or-pid-privileges"

--- a/controls/C-0041/policy.yaml
+++ b/controls/C-0041/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0041-deny-resources-with-host-network-access"

--- a/controls/C-0042/policy.yaml
+++ b/controls/C-0042/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0042-deny-resources-with-ssh-server-running"

--- a/controls/C-0044/policy.yaml
+++ b/controls/C-0044/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0044-deny-resources-with-host-port"

--- a/controls/C-0045/policy.yaml
+++ b/controls/C-0045/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0045-deny-workloads-with-hostpath-volumes-readonly-not-false"

--- a/controls/C-0046/policy.yaml
+++ b/controls/C-0046/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0046-deny-resources-with-insecure-capabilities"

--- a/controls/C-0048/policy.yaml
+++ b/controls/C-0048/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0048-deny-workloads-with-hostpath-mounts"

--- a/controls/C-0050/policy.yaml
+++ b/controls/C-0050/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0050-deny-resources-with-cpu-limit-or-request-not-set"

--- a/controls/C-0055/policy.yaml
+++ b/controls/C-0055/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0055-linux-hardening"

--- a/controls/C-0056/policy.yaml
+++ b/controls/C-0056/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0056-deny-resources-without-configured-liveliness-probes"

--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0057-privileged-container-denied"

--- a/controls/C-0061/policy.yaml
+++ b/controls/C-0061/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0061-deny-workloads-in-default-namespace"

--- a/controls/C-0062/policy.yaml
+++ b/controls/C-0062/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0062-deny-resources-having-containers-with-sudo-in-entrypoint"

--- a/controls/C-0073/policy.yaml
+++ b/controls/C-0073/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0073-deny-naked-pods"

--- a/controls/C-0074/policy.yaml
+++ b/controls/C-0074/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0074-resources-mounting-docker-socket-denied"

--- a/controls/C-0075/policy.yaml
+++ b/controls/C-0075/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0075-deny-resources-with-image-pull-policy-not-set-to-always-for-latest-tag"

--- a/controls/C-0076/policy.yaml
+++ b/controls/C-0076/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set"

--- a/controls/C-0077/policy.yaml
+++ b/controls/C-0077/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set"

--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0078-only-allow-images-from-allowed-registry"

--- a/docs/validating-admission-policies/README.md
+++ b/docs/validating-admission-policies/README.md
@@ -2,7 +2,11 @@
 
 ## Cluster
 
-[Validating Admission Policies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) have been introduced in Kubernetes 1.26 and they are under feature gate. In order to enable them:
+[Validating Admission Policies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) have been introduced in Kubernetes 1.26 and they are under feature-gate. This feature was released for GA in Kubernetes 1.30 (without feature-gate).
+
+### Older Kubernetes versions (1.26 throughout 1.29)
+
+You need to enable the feature-gate in the API Server. In order to enable them:
 * turn on `ValidatingAdmissionPolicy` feature gate
 * turn on `admissionregistration.k8s.io/v1alpha1` or `admissionregistration.k8s.io/v1beta1` depending on whether you are using 1.26/1.27 (alpha) or 1.28 (beta)
 
@@ -11,6 +15,10 @@ For minikube users, this is an example of how to enable:
 ```bash
 minikube start --kubernetes-version=v1.28.0-rc.1 --extra-config=apiserver.runtime-config=admissionregistration.k8s.io/v1beta1  --feature-gates='ValidatingAdmissionPolicy=true'
 ```
+
+### Newer versions (1.30 and above)
+
+You don't need to do anything, *VAP* is available out of the box 😉
 
 ## Overview
 
@@ -29,7 +37,7 @@ kubectl label namespace vap-playground vap=enabled
 
 Here is an example policy for denying Pods without `app` label:
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: deny-pods-without-app-label

--- a/docs/validating-admission-policies/deny-pods-without-app-label-policy-binding.yaml
+++ b/docs/validating-admission-policies/deny-pods-without-app-label-policy-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: deny-pods-without-app-label-binding

--- a/docs/validating-admission-policies/deny-pods-without-app-label-policy.yaml
+++ b/docs/validating-admission-policies/deny-pods-without-app-label-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: deny-pods-without-app-label

--- a/runtime-policies/attach/policy.yaml
+++ b/runtime-policies/attach/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-attach
@@ -13,4 +13,3 @@ spec:
   validations:
   - expression: "false"
     message: "attach is not allowed"
-    reason: "Medium"

--- a/runtime-policies/exec/policy.yaml
+++ b/runtime-policies/exec/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-exec
@@ -13,4 +13,3 @@ spec:
   validations:
   - expression: "false"
     message: "exec is not allowed"
-    reason: "High"

--- a/runtime-policies/hostmount/policy.yaml
+++ b/runtime-policies/hostmount/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-host-mount
@@ -21,10 +21,7 @@ spec:
   validations:
     - expression: "object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the Pod! (see more at https://hub.armosec.io/docs/c-0048)"
-      reason: "Medium"
     - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)"
-      reason: "Medium"
     - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)"
-      reason: "Medium"

--- a/runtime-policies/insecure-capabilities/policy.yaml
+++ b/runtime-policies/insecure-capabilities/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-insecure-capabilities
@@ -29,7 +29,6 @@ spec:
         container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
         ))
       message: "Pod has one or more containers with insecure capabilities! (see more at https://hub.armosec.io/docs/c-0046)"
-      reason: "High"
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
         object.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
@@ -37,7 +36,6 @@ spec:
         container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
         ))
       message: "Workload has one or more containers with insecure capabilities! (see more at https://hub.armosec.io/docs/c-0046)"
-      reason: "High"
     - expression: >
         object.kind != 'CronJob' ||
         object.spec.jobTemplate.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
@@ -45,4 +43,3 @@ spec:
         container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
         ))
       message: "CronJob has one or more containers with insecure capabilities! (see more at https://hub.armosec.io/docs/c-0046)"
-      reason: "High"

--- a/runtime-policies/portforward/policy.yaml
+++ b/runtime-policies/portforward/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-portforward
@@ -7,10 +7,9 @@ spec:
     resourceRules:
     - apiGroups:   [""]
       apiVersions: ["v1"]
-      operations:  ["UPDATE", "PATCH", "CONNECT"]
+      operations:  ["UPDATE", "CONNECT"]
       resources:   ["pods/portforward"]
   failurePolicy: Fail
   validations:
   - expression: "false"
     message: "portforward is not allowed"
-    reason: "High"

--- a/runtime-policies/privileged/policy.yaml
+++ b/runtime-policies/privileged/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cluster-policy-deny-priviliged-flag

--- a/test-resources/policy-binding.yaml
+++ b/test-resources/policy-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: placeholder


### PR DESCRIPTION
With the GA release of VAP in Kubernetes 1.30 we are aligning the CEL library with the `v1` API
* Updating policy objects
* Changed CI to use `v1`
* Changing documentation