### PR TITLE
Add Controls C-0268, C-0269, C-0270, C-0271 to allow for more fine granular testing of cpu/mem limits/requests being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0268](https://hub.armosec.io/docs/c-0268) | Ensure CPU requests are set | [kubescape-c-0268-deny-resources-with-cpu-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md) | [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpurequestmin) |
 | [C-0269](https://hub.armosec.io/docs/c-0269) | Ensure memory requests are set | [kubescape-c-0269-deny-resources-with-memory-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0269-deny-resources-with-memory-request-not-set.md) | [memoryRequestMin](https://hub.armosec.io/docs/configuration_parameter_memoryrequestmin) |
 | [C-0270](https://hub.armosec.io/docs/c-0270) | Ensure CPU limits are set | [kubescape-c-0270-deny-resources-with-cpu-limit-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0270-deny-resources-with-cpu-limit-not-set.md) | [cpuLimitMin](https://hub.armosec.io/docs/configuration_parameter_cpulimitmin) |
+| [C-0271](https://hub.armosec.io/docs/c-0271) | Ensure memory limits are set | [kubescape-c-0271-deny-resources-with-memory-limit-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0271-deny-resources-with-memory-limit-not-set.md) | [memoryLimitMin](https://hub.armosec.io/docs/configuration_parameter_memorylimitmin) |
 
 ## Testing Policies
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0077](https://hub.armosec.io/docs/c-0077) | K8s common labels usage | [kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set.md) | [k8sRecommendedLabels](https://hub.armosec.io/docs/configuration_parameter_k8srecommendedlabels) |
 | [C-0078](https://hub.armosec.io/docs/c-0078) | Images from allowed registry | [kubescape-c-0078-only-allow-images-from-allowed-registry](/docs/policies-based-on-kubescape-controls/kubescape-c-0078-only-allow-images-from-allowed-registry.md) | [imageRepositoryAllowList](https://hub.armosec.io/docs/configuration_parameter_imagerepositoryallowlist) |
 | [C-0268](https://hub.armosec.io/docs/c-0268) | Ensure CPU requests are set | [kubescape-c-0268-deny-resources-with-cpu-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md) | [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpurequestmin) |
+| [C-0269](https://hub.armosec.io/docs/c-0269) | Ensure memory requests are set | [kubescape-c-0269-deny-resources-with-memory-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0269-deny-resources-with-memory-request-not-set.md) | [memoryRequestMin](https://hub.armosec.io/docs/configuration_parameter_memoryrequestmin) |
 
 ## Testing Policies
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0076](https://hub.armosec.io/docs/c-0076) | Label usage for resources | [kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0076-deny-resources-without-configured-list-of-labels-not-set.md) | [recommendedLabels](https://hub.armosec.io/docs/configuration_parameter_recommendedlabels) |
 | [C-0077](https://hub.armosec.io/docs/c-0077) | K8s common labels usage | [kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0077-deny-resources-without-configured-list-of-k8s-common-labels-not-set.md) | [k8sRecommendedLabels](https://hub.armosec.io/docs/configuration_parameter_k8srecommendedlabels) |
 | [C-0078](https://hub.armosec.io/docs/c-0078) | Images from allowed registry | [kubescape-c-0078-only-allow-images-from-allowed-registry](/docs/policies-based-on-kubescape-controls/kubescape-c-0078-only-allow-images-from-allowed-registry.md) | [imageRepositoryAllowList](https://hub.armosec.io/docs/configuration_parameter_imagerepositoryallowlist) |
+| [C-0268](https://hub.armosec.io/docs/c-0268) | Ensure CPU requests are set | [kubescape-c-0268-deny-resources-with-cpu-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md) | [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpurequestmin) |
 
 ## Testing Policies
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0078](https://hub.armosec.io/docs/c-0078) | Images from allowed registry | [kubescape-c-0078-only-allow-images-from-allowed-registry](/docs/policies-based-on-kubescape-controls/kubescape-c-0078-only-allow-images-from-allowed-registry.md) | [imageRepositoryAllowList](https://hub.armosec.io/docs/configuration_parameter_imagerepositoryallowlist) |
 | [C-0268](https://hub.armosec.io/docs/c-0268) | Ensure CPU requests are set | [kubescape-c-0268-deny-resources-with-cpu-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md) | [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpurequestmin) |
 | [C-0269](https://hub.armosec.io/docs/c-0269) | Ensure memory requests are set | [kubescape-c-0269-deny-resources-with-memory-request-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0269-deny-resources-with-memory-request-not-set.md) | [memoryRequestMin](https://hub.armosec.io/docs/configuration_parameter_memoryrequestmin) |
+| [C-0270](https://hub.armosec.io/docs/c-0270) | Ensure CPU limits are set | [kubescape-c-0270-deny-resources-with-cpu-limit-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0270-deny-resources-with-cpu-limit-not-set.md) | [cpuLimitMin](https://hub.armosec.io/docs/configuration_parameter_cpulimitmin) |
 
 ## Testing Policies
 

--- a/controls/C-0050/policy.yaml
+++ b/controls/C-0050/policy.yaml
@@ -28,8 +28,8 @@ spec:
   validations:
     - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
@@ -37,8 +37,8 @@ spec:
 
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
@@ -46,8 +46,8 @@ spec:
 
     - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.requests.cpu)) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)) &&
         (!(!(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
         params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
         params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))

--- a/controls/C-0268/policy.yaml
+++ b/controls/C-0268/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0268-deny-resources-with-cpu-request-not-set"
+  labels:
+    controlId: "C-0268"
+  annotations:
+    controlUrl: "https://hub.armosec.io/docs/c-0268"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+      message: "Pods contains container/s with cpu request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0268)"
+
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+      message: "Workloads contains container/s with cpu request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0268)"
+
+    - expression: >
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
+        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
+        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+      message: "CronJob contains container/s with cpu request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0268)"

--- a/controls/C-0268/tests.json
+++ b/controls/C-0268/tests.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "Pod with container having cpu request not set is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Pod with container having cpu request set and value in the limit is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].resources.requests.cpu=3"
+        ]
+    },
+    {
+        "name": "Pod with container having cpu request set and value not in the limit is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].resources.requests.cpu=6"
+        ]
+    },
+    {
+        "name": "Deployment with container having cpu request not set is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Deployment with container having cpu request set and value in the limit is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].resources.requests.cpu=3"
+        ]
+    }
+]

--- a/controls/C-0269/policy.yaml
+++ b/controls/C-0269/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0269-deny-resources-with-memory-request-not-set"
+  labels:
+    controlId: "C-0269"
+  annotations:
+    controlUrl: "https://hub.armosec.io/docs/c-0269"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
+        params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
+        params.settings.memoryRequestMax >= int(container.resources.requests.memory)))
+      message: "Pods contains container/s with memory request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0269)"
+
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
+        params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
+        params.settings.memoryRequestMax >= int(container.resources.requests.memory)))
+      message: "Workloads contains container/s with memory request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0269)"
+
+    - expression: >
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
+        params.settings.memoryRequestMin <= int(container.resources.requests.memory) &&
+        params.settings.memoryRequestMax >= int(container.resources.requests.memory)))
+      message: "CronJob contains container/s with memory request not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0269)"

--- a/controls/C-0269/tests.json
+++ b/controls/C-0269/tests.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "Pod with container having memory request not set is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+        ]
+    },
+    {
+        "name": "Pod with container having memory request set and value in the limit is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].resources.requests.memory=128"
+        ]
+    },
+    {
+        "name": "Pod with container having memory request set and value not in the limit is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].resources.requests.memory=512"
+        ]
+    },
+    {
+        "name": "Deployment with container having memory request not set is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Deployment with container having memory request set and value in the limit is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].resources.requests.memory=128"
+        ]
+    }
+]

--- a/controls/C-0270/policy.yaml
+++ b/controls/C-0270/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0270-deny-resources-with-cpu-limit-not-set"
+  labels:
+    controlId: "C-0270"
+  annotations:
+    controlUrl: "https://hub.armosec.io/docs/c-0270"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
+        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
+        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      message: "Pods contains container/s with cpu limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0270)"
+
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
+        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
+        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      message: "Workloads contains container/s with cpu limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0270)"
+
+    - expression: >
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
+        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
+        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+      message: "CronJob contains container/s with cpu limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0270)"

--- a/controls/C-0270/tests.json
+++ b/controls/C-0270/tests.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "Pod with container having cpu limits not set is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Pod with container having cpu limits set and value in the limit is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].resources.limits.cpu=3"
+        ]
+    },
+    {
+        "name": "Pod with container having cpu limits set and value not in the limit is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].resources.limits.cpu=6"
+        ]
+    },
+    {
+        "name": "Deployment with container having cpu limits not set is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Deployment with container having cpu limits set and value in the limit is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].resources.limits.cpu=3"
+        ]
+    }
+]

--- a/controls/C-0271/policy.yaml
+++ b/controls/C-0271/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0271-deny-resources-with-memory-limit-not-set"
+  labels:
+    controlId: "C-0271"
+  annotations:
+    controlUrl: "https://hub.armosec.io/docs/c-0271"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: kubescape.io/v1
+    kind: ControlConfiguration
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  validations:
+    - expression: >
+        object.kind != 'Pod' || object.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
+        params.settings.memoryLimitMin <= int(container.resources.limits.memory) &&
+        params.settings.memoryLimitMax >= int(container.resources.limits.memory)))
+      message: "Pods contains container/s with memory limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0271)"
+
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
+        params.settings.memoryLimitMin <= int(container.resources.limits.memory) &&
+        params.settings.memoryLimitMax >= int(container.resources.limits.memory)))
+      message: "Workloads contains container/s with memory limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0271)"
+
+    - expression: >
+        object.kind != 'CronJob' || object.spec.jobTemplate.spec.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
+        params.settings.memoryLimitMin <= int(container.resources.limits.memory) &&
+        params.settings.memoryLimitMax >= int(container.resources.limits.memory)))
+      message: "CronJob contains container/s with memory limit not set or they are not in the specified range! (see more at https://hub.armosec.io/docs/c-0271)"

--- a/controls/C-0271/tests.json
+++ b/controls/C-0271/tests.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "Pod with container having memory limits not set is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Pod with container having memory limits set and value in the limit is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].resources.limits.memory=128"
+        ]
+    },
+    {
+        "name": "Pod with container having memory limits set and value not in the limit is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].resources.limits.memory=512"
+        ]
+    },
+    {
+        "name": "Deployment with container having memory limits not set is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [ 
+        ]
+    },
+    {
+        "name": "Deployment with container having memory limits set and value in the limit is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].resources.limits.memory=128"
+        ]
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
 - C-0050/policy.yaml
 - C-0268/policy.yaml
 - C-0269/policy.yaml
+- C-0270/policy.yaml

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
 - C-0044/policy.yaml
 - C-0057/policy.yaml
 - C-0050/policy.yaml
+- C-0268/policy.yaml

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -29,3 +29,4 @@ resources:
 - C-0268/policy.yaml
 - C-0269/policy.yaml
 - C-0270/policy.yaml
+- C-0271/policy.yaml

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
 - C-0057/policy.yaml
 - C-0050/policy.yaml
 - C-0268/policy.yaml
+- C-0269/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0268-deny-resources-with-cpu-request-not-set.md
@@ -1,0 +1,27 @@
+# Kubescape C-0268: Deny Resources with cpu request not set
+
+## Severity Level: High
+
+## Configuration Parameters:
+* [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpu_request_min).
+* [cpuRequestMax](https://hub.armosec.io/docs/configuration_parameter_cpu_request_max).
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+### This Policy checks for every container in the resource:
+* If `resources.requests.cpu` is set.
+* If `resources.requests.cpu` >= [cpuRequestMin](https://hub.armosec.io/docs/configuration_parameter_cpu_request_min).
+* If `resources.requests.cpu` <= [cpuRequestMax](https://hub.armosec.io/docs/configuration_parameter_cpu_request_max).
+
+If any of the above checks fail, the resource is denied from being deployed in the cluster.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0269-deny-resources-with-memory-request-not-set.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0269-deny-resources-with-memory-request-not-set.md
@@ -1,0 +1,27 @@
+# Kubescape C-0269: Deny Resources with memory request not set
+
+## Severity Level: High
+
+## Configuration Parameters:
+* [memoryRequestMin](https://hub.armosec.io/docs/configuration_parameter_memory_request_min).
+* [memoryRequestMax](https://hub.armosec.io/docs/configuration_parameter_memory_request_max).
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+### This Policy checks for every container in the resource:
+* If `resources.requests.memory` is set.
+* If `resources.requests.memory` >= [memoryRequestMin](https://hub.armosec.io/docs/configuration_parameter_memory_request_min).
+* If `resources.requests.memory` <= [memoryRequestMax](https://hub.armosec.io/docs/configuration_parameter_memory_request_max).
+
+If any of the above checks fail, the resource is denied from being deployed in the cluster.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0270-deny-resources-with-cpu-limit-not-set.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0270-deny-resources-with-cpu-limit-not-set.md
@@ -1,0 +1,27 @@
+# Kubescape C-0270: Deny Resources with cpu limit not set
+
+## Severity Level: High
+
+## Configuration Parameters:
+* [cpuLimitMin](https://hub.armosec.io/docs/configuration_parameter_cpu_limit_min).
+* [cpuLimitMax](https://hub.armosec.io/docs/configuration_parameter_cpu_limit_max).
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+### This Policy checks for every container in the resource:
+* If `resources.limits.cpu` is set.
+* If `resources.limits.cpu` >= [cpuLimitMin](https://hub.armosec.io/docs/configuration_parameter_cpu_limit_min).
+* If `resources.limits.cpu` <= [cpuLimitMax](https://hub.armosec.io/docs/configuration_parameter_cpu_limit_max).
+
+If any of the above checks fail, the resource is denied from being deployed in the cluster.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0271-deny-resources-with-memory-limit-not-set.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0271-deny-resources-with-memory-limit-not-set.md
@@ -1,0 +1,27 @@
+# Kubescape C-0271: Deny Resources with memory limit not set
+
+## Severity Level: High
+
+## Configuration Parameters:
+* [memoryLimitMin](https://hub.armosec.io/docs/configuration_parameter_memory_limit_min).
+* [memoryLimitMax](https://hub.armosec.io/docs/configuration_parameter_memory_limit_max).
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+### This Policy checks for every container in the resource:
+* If `resources.limits.memory` is set.
+* If `resources.limits.memory` >= [memoryLimitMin](https://hub.armosec.io/docs/configuration_parameter_memory_limit_min).
+* If `resources.limits.memory` <= [memoryLimitMax](https://hub.armosec.io/docs/configuration_parameter_memory_limit_max).
+
+If any of the above checks fail, the resource is denied from being deployed in the cluster.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)


### PR DESCRIPTION
Currently it is only possible to check for cpu/memory requests **and** limits. Since it is not recommended to set cpu limits when cpu requests are correctly set (see [this post e.g.](https://home.robusta.dev/blog/stop-using-cpu-limits)) the controls C-0004 and C-0050 are being split up into C-0268 to C-0271 like it has already been done in the regolibrary (https://github.com/kubescape/regolibrary/pull/594).

Also the control C-0050 contained a bug where cpu requests were compared to the configured max/min cpu limit.