### PR TITLE
Mishandling the cronjob volumes path

### DIFF
--- a/controls/C-0020/policy.yaml
+++ b/controls/C-0020/policy.yaml
@@ -111,7 +111,7 @@ spec:
       message: "Workload contains volumes with potential access to known cloud credentials! (see more at https://hub.armosec.io/docs/c-0020)"
 
     - expression: >
-        object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol,
+        object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
           (params.settings.cloudProvider != 'eks' ||

--- a/controls/C-0048/policy.yaml
+++ b/controls/C-0048/policy.yaml
@@ -27,5 +27,5 @@ spec:
       message: "There are one or more hostPath mounts in the Pod! (see more at https://hub.armosec.io/docs/c-0048)"
     - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)"
-    - expression: "object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
+    - expression: "object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)"

--- a/controls/C-0074/policy.yaml
+++ b/controls/C-0074/policy.yaml
@@ -42,7 +42,7 @@ spec:
         ))
       message: "Workload has one or more containers mounting Docker socket! (see more at https://hub.armosec.io/docs/c-0074)"
     - expression: >
-        object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.volumes)) ||
+        object.kind != 'CronJob' || !(has(object.spec.jobTemplate.spec.template.spec.volumes)) ||
         object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         !(has(vol.hostPath.path)) ||
         (


### PR DESCRIPTION
This pull request includes changes to several policy files to correct the path used in expressions for `CronJob` objects. The updates ensure that the correct `template.spec.volumes` path is used consistently.

Changes to policy files:

* [`controls/C-0020/policy.yaml`](diffhunk://#diff-2747c12e53b91da8f284c291c695a89cc09104ec392290ca33e602dd2e46ccc1L114-R114): Corrected the path for `CronJob` volumes in the expression to use `template.spec.volumes` instead of `spec.volumes`.
* [`controls/C-0048/policy.yaml`](diffhunk://#diff-7e60e401550be027bdc02b8ef694ae382f56ef3b686e06f33201fe571c0452d8L30-R30): Updated the expression for `CronJob` volumes to use `template.spec.volumes` consistently.
* [`controls/C-0074/policy.yaml`](diffhunk://#diff-b25e820d6c479f7b5f71d397cfadf3636377a222f09fda6958faaa5bd768a97fL45-R45): Fixed the expression for `CronJob` volumes to reference `template.spec.volumes` correctly.