### PR TITLE
Add missing sensitiveKeyNamesAllowed parameter for C-0012

### DIFF
--- a/configuration/basic-control-configuration.yaml
+++ b/configuration/basic-control-configuration.yaml
@@ -92,6 +92,7 @@ settings:
   - Bearer
   - _key_
   - _secret_
+  sensitiveKeyNamesAllowed: []
   sensitiveValuesAllowed:
   - ''
   servicesNames:

--- a/configuration/policy-configuration-definition.yaml
+++ b/configuration/policy-configuration-definition.yaml
@@ -71,6 +71,10 @@ spec:
                   items:
                     type: string
                   type: array
+                sensitiveKeyNamesAllowed:
+                  items:
+                    type: string
+                  type: array
                 sensitiveValues:
                   items:
                     type: string

--- a/controls/C-0012/policy.yaml
+++ b/controls/C-0012/policy.yaml
@@ -25,37 +25,47 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["configmaps"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
+    - expression: |
+        object.kind == 'ConfigMap' ?
+          (has(object.data) ?
+            object.data
+            : (has(object.binaryData) ?
+              object.binaryData
+              : {}))
+        : {}
+      name: configMapData
   validations:
     # Note that if the value is mounted using a secret or a configMap, this policy will allow the resource to be deployed in the cluster.
+    - expression: |
+        variables.containers.all(container,
+          !has(container.env) || container.env.all(envVariable,
+            (
+                !params.settings.sensitiveKeyNames.exists(sensitiveKey, envVariable.name.lowerAscii().contains(sensitiveKey)) &&
+                !params.settings.sensitiveValues.exists(sensitiveVal, envVariable.value.matches(sensitiveVal))
+            ) ||
+            !has(envVariable.value) || (envVariable.value == "") ||
+            envVariable.value in params.settings.sensitiveValuesAllowed ||
+            params.settings.sensitiveKeyNamesAllowed.exists(sensitiveKeyName, envVariable.name.matches(sensitiveKeyName))
+          )
+        )
+      reason: Invalid
+      messageExpression: 'object.kind + "/" + object.metadata.name + " has one or more containers with sensitive information in environment variables! (see more at https://hub.armosec.io/docs/c-0012)"'
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container, !has(container.env) || container.env.all(envVariable,
-        !params.settings.sensitiveKeyNames.exists(sensitiveKey, envVariable.name.lowerAscii().contains(sensitiveKey)) ||
-        !has(envVariable.value) || (envVariable.value == "") ||
-        params.settings.sensitiveValuesAllowed.exists(allowedVal, envVariable.value == allowedVal)
-        ))
-      message: "Pods has one or more containers with sensitive information in environment variables! (see more at https://hub.armosec.io/docs/c-0012)"
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, !has(container.env) || container.env.all(envVariable,
-        !params.settings.sensitiveKeyNames.exists(sensitiveKey, envVariable.name.lowerAscii().contains(sensitiveKey)) ||
-        !has(envVariable.value) || (envVariable.value == "") ||
-        params.settings.sensitiveValuesAllowed.exists(allowedVal, envVariable.value == allowedVal)
-        ))
-      message: "Workloads has one or more containers with sensitive information in environment variables! (see more at https://hub.armosec.io/docs/c-0012)"
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, !has(container.env) || container.env.all(envVariable,
-        !params.settings.sensitiveKeyNames.exists(sensitiveKey, envVariable.name.lowerAscii().contains(sensitiveKey)) ||
-        !has(envVariable.value) || (envVariable.value == "") ||
-        params.settings.sensitiveValuesAllowed.exists(allowedVal, envVariable.value == allowedVal)
-        ))
-      message: "CronJob has one or more containers with sensitive information in environment variables! (see more at https://hub.armosec.io/docs/c-0012)"
-    - expression: >
-        object.kind != 'ConfigMap' || object.data.all(key,
+        variables.configMapData.all(key,
         (
           (
             !params.settings.sensitiveKeyNames.exists(sensitiveKey, key.lowerAscii().contains(sensitiveKey)) &&
             !params.settings.sensitiveValues.exists(sensitiveVal, key.lowerAscii().matches(sensitiveVal))
           ) ||
-          object.data[key] == "" ||
-          params.settings.sensitiveValuesAllowed.exists(allowedVal, object.data[key] == allowedVal)
+          variables.configMapData[key] == "" ||
+          variables.configMapData[key] in params.settings.sensitiveValuesAllowed ||
+          params.settings.sensitiveKeyNamesAllowed.exists(sensitiveKeyName, key.matches(sensitiveKeyName))
         ))
-      message: "ConfigMap contains sensitive information in its data! (see more at https://hub.armosec.io/docs/c-0012)"
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains sensitive information in its data! (see more at https://hub.armosec.io/docs/c-0012)"'

--- a/controls/C-0012/tests.json
+++ b/controls/C-0012/tests.json
@@ -4,14 +4,14 @@
         "template": "pod-for-list-items.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].env.[0].value=randomValue"    
+            "spec.containers.[0].env.[0].value=randomValue"
         ]
     },
     {
         "name": "Pod with container having env with sensitive key name and value not set is allowed",
         "template": "pod-for-list-items.yaml",
         "expected": "pass",
-        "field_change_list": [   
+        "field_change_list": [
         ]
     },
     {
@@ -19,7 +19,7 @@
         "template": "pod-for-list-items.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].env.[0].value=\"\""    
+            "spec.containers.[0].env.[0].value=\"\""
         ]
     },
     {
@@ -27,14 +27,14 @@
         "template": "pod-for-list-items.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].env.[0].value=test-value"    
+            "spec.containers.[0].env.[0].value=test-value"
         ]
     },
     {
         "name": "Pod with container having env without sensitive key name is allowed",
         "template": "pod.yaml",
         "expected": "pass",
-        "field_change_list": [   
+        "field_change_list": [
         ]
     },
     {
@@ -42,14 +42,14 @@
         "template": "deployment-for-list-items.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.template.spec.containers.[0].env.[0].value=randomValue"    
+            "spec.template.spec.containers.[0].env.[0].value=randomValue"
         ]
     },
     {
         "name": "Deployment with container having env with sensitive key name and value not set is allowed",
         "template": "deployment-for-list-items.yaml",
         "expected": "pass",
-        "field_change_list": [   
+        "field_change_list": [
         ]
     },
     {
@@ -57,7 +57,7 @@
         "template": "deployment-for-list-items.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].env.[0].value=\"\""    
+            "spec.template.spec.containers.[0].env.[0].value=\"\""
         ]
     },
     {
@@ -65,21 +65,21 @@
         "template": "deployment-for-list-items.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].env.[0].value=test-value"    
+            "spec.template.spec.containers.[0].env.[0].value=test-value"
         ]
     },
     {
         "name": "Deployment with container having env without sensitive key name is allowed",
         "template": "deployment.yaml",
         "expected": "pass",
-        "field_change_list": [    
+        "field_change_list": [
         ]
     },
     {
         "name": "ConfigMap without data having sensitiveKey and not matching sensitiveValues is allowed",
         "template": "configmap.yaml",
         "expected": "pass",
-        "field_change_list": [    
+        "field_change_list": [
         ]
     },
     {
@@ -94,16 +94,16 @@
         "name": "ConfigMap with data having sensitiveKey and value not from sensitiveValuesAllowed is denied",
         "template": "configmap.yaml",
         "expected": "fail",
-        "field_change_list": [  
-            "data.password=password123"  
+        "field_change_list": [
+            "data.password=password123"
         ]
     },
     {
         "name": "ConfigMap with data having sensitiveKey and value from sensitiveValuesAllowed is allowed",
         "template": "configmap.yaml",
         "expected": "pass",
-        "field_change_list": [  
-            "data.password=encrypted-password"  
+        "field_change_list": [
+            "data.password=encrypted-password"
         ]
     },
     {
@@ -118,16 +118,24 @@
         "name": "ConfigMap with data having sensitiveKey matching sensitiveValues and value not from sensitiveValuesAllowed is denied",
         "template": "configmap.yaml",
         "expected": "fail",
-        "field_change_list": [  
-            "data.topsecret=password123"  
+        "field_change_list": [
+            "data.topsecret=password123"
         ]
     },
     {
         "name": "ConfigMap with data having sensitiveKey matching sensitiveValues and value from sensitiveValuesAllowed is allowed",
         "template": "configmap.yaml",
         "expected": "pass",
-        "field_change_list": [  
-            "data.topsecret=encrypted-password"  
+        "field_change_list": [
+            "data.topsecret=encrypted-password"
+        ]
+    },
+    {
+        "name": "ConfigMap with data having sensitiveKey matching sensitiveKeyNames and sensitiveKeyNamesAllowed is allowed",
+        "template": "configmap.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "data.top-secret-allowed=password123"
         ]
     }
 ]

--- a/test-resources/default-control-configuration.yaml
+++ b/test-resources/default-control-configuration.yaml
@@ -85,6 +85,8 @@ settings:
   - jwt
   - bearer
   - credential
+  sensitiveKeyNamesAllowed:
+  - top-secret-allowed
   sensitiveValues:
   - BEGIN \w+ PRIVATE KEY
   - PRIVATE KEY


### PR DESCRIPTION
Add missing [`sensititveKeyNamesAllowed`](https://hub.armosec.io/docs/configuration_parameter_sensitivekeynamesallowed) parameter for [`C-0012`](https://hub.armosec.io/docs/c-0012) control.

Rewrite VAP using variables to reduce duplicate code and add more informative message upon faied validation.