### PR TITLE
fix automountServiceAccountToken for cronjob

### DIFF
--- a/controls/C-0034/policy.yaml
+++ b/controls/C-0034/policy.yaml
@@ -50,7 +50,7 @@ spec:
     - expression: >
         object.kind != 'CronJob' ||
         (
-          has(object.spec.jobTemplate.spec.automountServiceAccountToken) &&
-          object.spec.jobTemplate.spec.automountServiceAccountToken == false
+          has(object.spec.jobTemplate.spec.template.spec.automountServiceAccountToken) &&
+          object.spec.jobTemplate.spec.template.spec.automountServiceAccountToken == false
         )
       message: "CronJob has \"automountServiceAccountToken\" enabled! (see more at https://hub.armosec.io/docs/c-0034)"


### PR DESCRIPTION
This merge request a proposed fix for my issue #71.

The `spec.jobTemplate.spec.automountServiceAccountToken` field does not exist on a CronJob.

e.g.: `Error from server (BadRequest): error when creating "cronjob.yaml": CronJob in version "v1" cannot be handled as a CronJob: strict decoding error: unknown field "spec.jobTemplate.spec.automountServiceAccountToken"`

The field is located in the PodSpec at `spec.jobTemplate.spec.template.spec.automountServiceAccountToken`.
