### PR TITLE
Fix writable host mount missing volume issue

### DIFF
--- a/controls/C-0045/policy.yaml
+++ b/controls/C-0045/policy.yaml
@@ -24,21 +24,21 @@ spec:
       resources:   ["jobs","cronjobs"]
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)) ||
+        object.kind != 'Pod' || (!has(object.spec.volumes)) || object.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||
           (has(containerVol.readOnly) && containerVol.readOnly == true)
         )))
       message: "One or more hostPath Volumes in the Pod has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (!has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||
           (has(containerVol.readOnly) && containerVol.readOnly == true)
         )))
       message: "One or more hostPath Volumes in the Workload has readOnly not set to false! (see more at https://hub.armosec.io/docs/c-0045)"
     - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
+        object.kind != 'CronJob' || (!has(object.spec.jobTemplate.spec.template.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)) ||
         object.spec.jobTemplate.spec.template.spec.containers.all(container, !(has(container.volumeMounts)) || container.volumeMounts.all(
           containerVol, containerVol.name != vol.name ||
           (has(containerVol.readOnly) && containerVol.readOnly == true)

--- a/controls/C-0045/tests.json
+++ b/controls/C-0045/tests.json
@@ -7,6 +7,13 @@
         ]
     },
     {
+        "name": "Pod with no volumes",
+        "template": "pod-no-volume.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
+    },
+    {
         "name": "Pod with hostPath volume and readOnly is not set for corresponding volumeMount is denied",
         "template": "pod.yaml",
         "expected": "fail",
@@ -20,7 +27,7 @@
         "expected": "fail",
         "field_change_list": [
             "spec.volumes.[0].hostPath.path=/var",
-            "spec.containers.[0].volumeMounts.[0].readOnly=false"    
+            "spec.containers.[0].volumeMounts.[0].readOnly=false"
         ]
     },
     {
@@ -29,7 +36,7 @@
         "expected": "pass",
         "field_change_list": [
             "spec.volumes.[0].hostPath.path=/var",
-            "spec.containers.[0].volumeMounts.[0].readOnly=true"    
+            "spec.containers.[0].volumeMounts.[0].readOnly=true"
         ]
     },
     {
@@ -53,7 +60,7 @@
         "expected": "fail",
         "field_change_list": [
             "spec.template.spec.volumes.[0].hostPath.path=/var",
-            "spec.template.spec.containers.[0].volumeMounts.[0].readOnly=false"    
+            "spec.template.spec.containers.[0].volumeMounts.[0].readOnly=false"
         ]
     },
     {
@@ -62,7 +69,7 @@
         "expected": "pass",
         "field_change_list": [
             "spec.template.spec.volumes.[0].hostPath.path=/var",
-            "spec.template.spec.containers.[0].volumeMounts.[0].readOnly=true"    
+            "spec.template.spec.containers.[0].volumeMounts.[0].readOnly=true"
         ]
     }
 ]

--- a/runtime-policies/hostmount/policy.yaml
+++ b/runtime-policies/hostmount/policy.yaml
@@ -19,9 +19,9 @@ spec:
       resources:   ["jobs","cronjobs"]
   failurePolicy: Fail
   validations:
-    - expression: "object.kind != 'Pod' || object.spec.volumes.all(vol, !(has(vol.hostPath)))"
+    - expression: "object.kind != 'Pod' || (!has(object.spec.volumes)) || object.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the Pod! (see more at https://hub.armosec.io/docs/c-0048)"
-    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
+    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || (!has(object.spec.template.spec.volumes)) || object.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the Workload! (see more at https://hub.armosec.io/docs/c-0048)"
-    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
+    - expression: "object.kind != 'CronJob' || (!has(object.spec.jobTemplate.spec.template.spec.volumes)) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol, !(has(vol.hostPath)))"
       message: "There are one or more hostPath mounts in the CronJob! (see more at https://hub.armosec.io/docs/c-0048)"

--- a/test-resources/pod-no-volume.yaml
+++ b/test-resources/pod-no-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    admission-policy-test: abc
+spec:
+  containers:
+  - name: sleep
+    image: alpine
+    command: ["sh"]
+    args: ["-c", "while true; do sleep 1; done"]
+    ports:
+    - containerPort: 8086


### PR DESCRIPTION
This pull request enhances validation logic in admission policies to handle cases where volumes may not exist and adds a new test resource for better policy coverage. The key changes include updating validation expressions to account for missing volumes, adding a new test case, and introducing a corresponding test resource.

Fixes #73 

### Validation Logic Enhancements:
* Updated validation expressions in `controls/C-0045/policy.yaml` to include checks for the existence of volumes before applying further conditions. This ensures the policy does not fail when volumes are absent.
* Applied similar updates to validation expressions in `runtime-policies/hostmount/policy.yaml` to handle missing volumes consistently across different resource types.

### Test Coverage Improvements:
* Added a new test case in `controls/C-0045/tests.json` to validate the scenario where a Pod has no volumes, ensuring the policy passes in such cases.
* Introduced a new test resource file, `test-resources/pod-no-volume.yaml`, representing a Pod without volumes, to support the new test case.