### PR TITLE
Fix cpu limit/request control type conversion error

### DIFF
--- a/controls/C-0268/policy.yaml
+++ b/controls/C-0268/policy.yaml
@@ -29,20 +29,20 @@ spec:
     - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+        quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 &&
+        quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1 ))
       message: "Pods contains container/s with cpu request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0268/)"
 
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+        quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 &&
+        quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1 ))
       message: "Workloads contains container/s with cpu request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0268/)"
 
     - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.cpu))) &&
-        params.settings.cpuRequestMin <= int(container.resources.requests.cpu) &&
-        params.settings.cpuRequestMax >= int(container.resources.requests.cpu)))
+        quantity(string(params.settings.cpuRequestMin)).compareTo(quantity(string(container.resources.requests.cpu))) != 1 &&
+        quantity(string(params.settings.cpuRequestMax)).compareTo(quantity(string(container.resources.requests.cpu))) != -1 ))
       message: "CronJob contains container/s with cpu request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0268/)"

--- a/controls/C-0270/policy.yaml
+++ b/controls/C-0270/policy.yaml
@@ -29,20 +29,20 @@ spec:
     - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+        quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 &&
+        quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1 ))
       message: "Pods contains container/s with cpu limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"
 
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+        quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 &&
+        quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1 ))
       message: "Workloads contains container/s with cpu limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"
 
     - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.cpu))) &&
-        params.settings.cpuLimitMin <= int(container.resources.limits.cpu) &&
-        params.settings.cpuLimitMax >= int(container.resources.limits.cpu)))
+        quantity(string(params.settings.cpuLimitMin)).compareTo(quantity(string(container.resources.limits.cpu))) != 1 &&
+        quantity(string(params.settings.cpuLimitMax)).compareTo(quantity(string(container.resources.limits.cpu))) != -1 ))
       message: "CronJob contains container/s with cpu limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"


### PR DESCRIPTION
The Controls `C-0268` and `C-0270`, used to validate cpu limits and requests, now use the [CEL K8s Quantity Library](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-quantity-library). The previous expression could fail when the value was not an int (e.g. `0.5`) which resulted in the following error message:
`[…] resulted in error: type conversion error from 'string' to 'int'`.