### PR TITLE
fix: Allow usage of floats on C-0004,  C-0269 and C-0271

### DIFF
--- a/configuration/basic-control-configuration.yaml
+++ b/configuration/basic-control-configuration.yaml
@@ -45,10 +45,10 @@ settings:
   - 5
   maxHighVulnerabilities:
   - 10
-  memoryLimitMax: 4294967296
-  memoryLimitMin: 0
-  memoryRequestMax: 4294967296
-  memoryRequestMin: 0
+  memoryLimitMax: 4Gi
+  memoryLimitMin: 0.25Gi
+  memoryRequestMax: 4Gi
+  memoryRequestMin: 0.125Gi
   publicRegistries:
   - docker.io
   - gcr.io

--- a/configuration/policy-configuration-definition.yaml
+++ b/configuration/policy-configuration-definition.yaml
@@ -48,13 +48,13 @@ spec:
                     type: integer
                   type: array
                 memoryLimitMax:
-                  type: integer
+                  type: number
                 memoryLimitMin:
-                  type: integer
+                  type: number
                 memoryRequestMax:
-                  type: integer
+                  type: number
                 memoryRequestMin:
-                  type: integer
+                  type: number
                 publicRegistries:
                   items:
                     type: string

--- a/configuration/policy-configuration-definition.yaml
+++ b/configuration/policy-configuration-definition.yaml
@@ -48,13 +48,13 @@ spec:
                     type: integer
                   type: array
                 memoryLimitMax:
-                  type: number
+                  type: string
                 memoryLimitMin:
-                  type: number
+                  type: string
                 memoryRequestMax:
-                  type: number
+                  type: string
                 memoryRequestMin:
-                  type: number
+                  type: string
                 publicRegistries:
                   items:
                     type: string

--- a/controls/C-0004/policy.yaml
+++ b/controls/C-0004/policy.yaml
@@ -25,30 +25,24 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) &&
-        (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger()&&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "Pods contains container/s with memory limit or request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0004/)"
-
+        variables.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
+        quantity(string(params.settings.memoryRequestMin)).compareTo(quantity(string(container.resources.requests.memory))) != 1 &&
+        quantity(string(params.settings.memoryRequestMax)).compareTo(quantity(string(container.resources.requests.memory))) != -1 ))
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0268/)"'
+    
     - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) &&
-        (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() &&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "Workloads contains container/s with memory limit or request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0004/)"
-
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()) &&
-        (!(!(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() &&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "CronJob contains container/s with memory limit or request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0004/)"
+        variables.containers.all(container,
+        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
+        quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 &&
+        quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"'

--- a/controls/C-0004/policy.yaml
+++ b/controls/C-0004/policy.yaml
@@ -38,11 +38,11 @@ spec:
         (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
         quantity(string(params.settings.memoryRequestMin)).compareTo(quantity(string(container.resources.requests.memory))) != 1 &&
         quantity(string(params.settings.memoryRequestMax)).compareTo(quantity(string(container.resources.requests.memory))) != -1 ))
-      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0268/)"'
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0004/)"'
     
     - expression: >
         variables.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
         quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 &&
         quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
-      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"'
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0004/)"'

--- a/controls/C-0004/tests.json
+++ b/controls/C-0004/tests.json
@@ -20,7 +20,7 @@
         "expected": "pass",
         "field_change_list": [
             "spec.containers.[0].resources.requests.memory=128Mi",
-            "spec.containers.[0].resources.limits.memory=128Mi"
+            "spec.containers.[0].resources.limits.memory=256Mi"
         ]
     },
     {
@@ -28,8 +28,8 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].resources.requests.memory=16Mi",
-            "spec.containers.[0].resources.limits.memory=512Gi"
+            "spec.containers.[0].resources.requests.memory=127Mi",
+            "spec.containers.[0].resources.limits.memory=1Gi"
         ]
     },
     {
@@ -45,7 +45,7 @@
         "expected": "pass",
         "field_change_list": [
             "spec.template.spec.containers.[0].resources.requests.memory=128Mi",
-            "spec.template.spec.containers.[0].resources.limits.memory=128Mi"
+            "spec.template.spec.containers.[0].resources.limits.memory=0.25Gi"
         ]
     },
     {
@@ -53,8 +53,8 @@
         "template": "cronjob.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.jobTemplate.spec.template.spec.containers.[0].resources.requests.memory=128Ki",
-            "spec.jobTemplate.spec.template.spec.containers.[0].resources.limits.memory=128Ki"
+            "spec.jobTemplate.spec.template.spec.containers.[0].resources.requests.memory=3.9Gi",
+            "spec.jobTemplate.spec.template.spec.containers.[0].resources.limits.memory=4096Mi"
         ]
     }
 ]

--- a/controls/C-0269/policy.yaml
+++ b/controls/C-0269/policy.yaml
@@ -25,24 +25,17 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container,
+        variables.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-      message: "Pods contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0269/)"
-
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
-        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-      message: "Workloads contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0269/)"
-
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
-        (!(!(has(container.resources)) || !(has(container.resources.requests)) || !(has(container.resources.requests.memory))) &&
-        params.settings.memoryRequestMin <= quantity(container.resources.requests.memory).asInteger() &&
-        params.settings.memoryRequestMax >= quantity(container.resources.requests.memory).asInteger()))
-      message: "CronJob contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0269/)"
+        quantity(string(params.settings.memoryRequestMin)).compareTo(quantity(string(container.resources.requests.memory))) != 1 &&
+        quantity(string(params.settings.memoryRequestMax)).compareTo(quantity(string(container.resources.requests.memory))) != -1 ))
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory request not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0269/)"'

--- a/controls/C-0269/tests.json
+++ b/controls/C-0269/tests.json
@@ -19,7 +19,7 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].resources.requests.memory=512Gi"
+            "spec.containers.[0].resources.requests.memory=4.1Gi"
         ]
     },
     {
@@ -34,7 +34,7 @@
         "template": "deployment.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].resources.requests.memory=128Mi"
+            "spec.template.spec.containers.[0].resources.requests.memory=0.25Gi"
         ]
     }
 ]

--- a/controls/C-0271/policy.yaml
+++ b/controls/C-0271/policy.yaml
@@ -25,24 +25,17 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container,
+        variables.containers.all(container,
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() &&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "Pods contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0271/)"
-
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
-        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() &&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "Workloads contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0271/)"
-
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
-        (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
-        params.settings.memoryLimitMin <= quantity(container.resources.limits.memory).asInteger() &&
-        params.settings.memoryLimitMax >= quantity(container.resources.limits.memory).asInteger()))
-      message: "CronJob contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0271/)"
+        quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 &&
+        quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"'

--- a/controls/C-0271/policy.yaml
+++ b/controls/C-0271/policy.yaml
@@ -38,4 +38,4 @@ spec:
         (!(!(has(container.resources)) || !(has(container.resources.limits)) || !(has(container.resources.limits.memory))) &&
         quantity(string(params.settings.memoryLimitMin)).compareTo(quantity(string(container.resources.limits.memory))) != 1 &&
         quantity(string(params.settings.memoryLimitMax)).compareTo(quantity(string(container.resources.limits.memory))) != -1 ))
-      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0270/)"'
+      messageExpression: 'object.kind + "/" + object.metadata.name + " contains container/s with memory limit not set or they are not in the specified range! (see more at https://kubescape.io/docs/controls/c-0271/)"'

--- a/controls/C-0271/tests.json
+++ b/controls/C-0271/tests.json
@@ -11,7 +11,7 @@
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].resources.limits.memory=128Mi"
+            "spec.containers.[0].resources.limits.memory=256Mi"
         ]
     },
     {
@@ -19,7 +19,7 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].resources.limits.memory=512Gi"
+            "spec.containers.[0].resources.limits.memory=4.1Gi"
         ]
     },
     {
@@ -34,7 +34,7 @@
         "template": "deployment.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].resources.limits.memory=128Mi"
+            "spec.template.spec.containers.[0].resources.limits.memory=0.5Gi"
         ]
     }
 ]

--- a/test-resources/default-control-configuration.yaml
+++ b/test-resources/default-control-configuration.yaml
@@ -46,10 +46,10 @@ settings:
   - 5
   maxHighVulnerabilities:
   - 10
-  memoryLimitMax: 4294967296
-  memoryLimitMin: 0
-  memoryRequestMax: 4294967296
-  memoryRequestMin: 0
+  memoryLimitMax: 4Gi
+  memoryLimitMin: 0.25Gi
+  memoryRequestMax: 4Gi
+  memoryRequestMin: 0.125Gi
   publicRegistries:
   - docker.io
   - gcr.io


### PR DESCRIPTION
The current rule doesn't work if the resource uses float quantities on memory, like `1.5Gi`. I rewrote the rules based on https://github.com/kubescape/cel-admission-library/pull/78.