### PR TITLE
Fix incorrect C-0013 and C-0055

### DIFF
--- a/controls/C-0013/policy.yaml
+++ b/controls/C-0013/policy.yaml
@@ -18,9 +18,22 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
+    - expression: |
+        object.kind == 'Pod' ? object.spec.securityContext
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.securityContext
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.securityContext
+        : {}
+      name: podSecurityContext
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container,
+        variables.containers.all(container,
           (
             has(container.securityContext) &&
             has(container.securityContext.allowPrivilegeEscalation) &&
@@ -38,9 +51,9 @@ spec:
                   !has(container.securityContext) || !has(container.securityContext.runAsNonRoot)
                 ) &&
                 (
-                  has(object.spec.securityContext) &&
-                  has(object.spec.securityContext.runAsNonRoot) &&
-                  object.spec.securityContext.runAsNonRoot == true
+                  has(variables.podSecurityContext) &&
+                  has(variables.podSecurityContext.runAsNonRoot) &&
+                  variables.podSecurityContext.runAsNonRoot == true
                 )
               )
             ) ||
@@ -55,104 +68,12 @@ spec:
                   !has(container.securityContext) || !has(container.securityContext.runAsUser)
                 ) &&
                 (
-                  has(object.spec.securityContext) &&
-                  has(object.spec.securityContext.runAsUser) &&
-                  object.spec.securityContext.runAsUser != 0
+                  has(variables.podSecurityContext) &&
+                  has(variables.podSecurityContext.runAsUser) &&
+                  variables.podSecurityContext.runAsUser != 0
                 )
               )
             )
           )
         )
-      message: "Pods contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
-
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
-          (
-            has(container.securityContext) &&
-            has(container.securityContext.allowPrivilegeEscalation) &&
-            container.securityContext.allowPrivilegeEscalation == false
-          ) &&
-          (
-            (
-              (
-                has(container.securityContext) &&
-                has(container.securityContext.runAsNonRoot) &&
-                container.securityContext.runAsNonRoot == true
-              ) ||
-              (
-                (
-                  !has(container.securityContext) || !has(container.securityContext.runAsNonRoot)
-                ) &&
-                (
-                  has(object.spec.template.spec.securityContext) &&
-                  has(object.spec.template.spec.securityContext.runAsNonRoot) &&
-                  object.spec.template.spec.securityContext.runAsNonRoot == true
-                )
-              )
-            ) ||
-            (
-              (
-                has(container.securityContext) &&
-                has(container.securityContext.runAsUser) &&
-                container.securityContext.runAsUser != 0
-              ) ||
-              (
-                (
-                  !has(container.securityContext) || !has(container.securityContext.runAsUser)
-                ) &&
-                (
-                  has(object.spec.template.spec.securityContext) &&
-                  has(object.spec.template.spec.securityContext.runAsUser) &&
-                  object.spec.template.spec.securityContext.runAsUser != 0
-                )
-              )
-            )
-          )
-        )
-      message: "Workloads contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
-
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
-          (
-            has(container.securityContext) &&
-            has(container.securityContext.allowPrivilegeEscalation) &&
-            container.securityContext.allowPrivilegeEscalation == false
-          ) &&
-          (
-            (
-              (
-                has(container.securityContext) &&
-                has(container.securityContext.runAsNonRoot) &&
-                container.securityContext.runAsNonRoot == true
-              ) ||
-              (
-                (
-                  !has(container.securityContext) || !has(container.securityContext.runAsNonRoot)
-                ) &&
-                (
-                  has(object.spec.jobTemplate.spec.template.spec.securityContext) &&
-                  has(object.spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot) &&
-                  object.spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot == true
-                )
-              )
-            ) ||
-            (
-              (
-                has(container.securityContext) &&
-                has(container.securityContext.runAsUser) &&
-                container.securityContext.runAsUser != 0
-              ) ||
-              (
-                (
-                  !has(container.securityContext) || !has(container.securityContext.runAsUser)
-                ) &&
-                (
-                  has(object.spec.jobTemplate.spec.template.spec.securityContext) &&
-                  has(object.spec.jobTemplate.spec.template.spec.securityContext.runAsUser) &&
-                  object.spec.jobTemplate.spec.template.spec.securityContext.runAsUser != 0
-                )
-              )
-            )
-          )
-        )
-      message: "CronJob contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
+      message: object.kind + "/" + object.metadata.name + " contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"

--- a/controls/C-0013/policy.yaml
+++ b/controls/C-0013/policy.yaml
@@ -22,21 +22,9 @@ spec:
     - expression: >
         object.kind != 'Pod' || object.spec.containers.all(container,
           (
-            (
-              has(container.securityContext) &&
-              has(container.securityContext.allowPrivilegeEscalation) &&
-              container.securityContext.allowPrivilegeEscalation == false
-            ) ||
-            (
-              (
-                !has(container.securityContext) || !has(container.securityContext.allowPrivilegeEscalation)
-              ) &&
-              (
-                has(object.spec.securityContext) &&
-                has(object.spec.securityContext.allowPrivilegeEscalation) &&
-                object.spec.securityContext.allowPrivilegeEscalation == false
-              )
-            )
+            has(container.securityContext) &&
+            has(container.securityContext.allowPrivilegeEscalation) &&
+            container.securityContext.allowPrivilegeEscalation == false
           ) &&
           (
             (
@@ -80,21 +68,9 @@ spec:
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
           (
-            (
-              has(container.securityContext) &&
-              has(container.securityContext.allowPrivilegeEscalation) &&
-              container.securityContext.allowPrivilegeEscalation == false
-            ) ||
-            (
-              (
-                !has(container.securityContext) || !has(container.securityContext.allowPrivilegeEscalation)
-              ) &&
-              (
-                has(object.spec.template.spec.securityContext) &&
-                has(object.spec.template.spec.securityContext.allowPrivilegeEscalation) &&
-                object.spec.template.spec.securityContext.allowPrivilegeEscalation == false
-              )
-            )
+            has(container.securityContext) &&
+            has(container.securityContext.allowPrivilegeEscalation) &&
+            container.securityContext.allowPrivilegeEscalation == false
           ) &&
           (
             (
@@ -138,21 +114,9 @@ spec:
     - expression: >
         object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
           (
-            (
-              has(container.securityContext) &&
-              has(container.securityContext.allowPrivilegeEscalation) &&
-              container.securityContext.allowPrivilegeEscalation == false
-            ) ||
-            (
-              (
-                !has(container.securityContext) || !has(container.securityContext.allowPrivilegeEscalation)
-              ) &&
-              (
-                has(object.spec.jobTemplate.spec.securityContext) &&
-                has(object.spec.jobTemplate.spec.securityContext.allowPrivilegeEscalation) &&
-                object.spec.jobTemplate.spec.securityContext.allowPrivilegeEscalation == false
-              )
-            )
+            has(container.securityContext) &&
+            has(container.securityContext.allowPrivilegeEscalation) &&
+            container.securityContext.allowPrivilegeEscalation == false
           ) &&
           (
             (
@@ -166,9 +130,9 @@ spec:
                   !has(container.securityContext) || !has(container.securityContext.runAsNonRoot)
                 ) &&
                 (
-                  has(object.spec.jobTemplate.spec.securityContext) &&
-                  has(object.spec.jobTemplate.spec.securityContext.runAsNonRoot) &&
-                  object.spec.jobTemplate.spec.securityContext.runAsNonRoot == true
+                  has(object.spec.jobTemplate.spec.template.spec.securityContext) &&
+                  has(object.spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot) &&
+                  object.spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot == true
                 )
               )
             ) ||
@@ -183,9 +147,9 @@ spec:
                   !has(container.securityContext) || !has(container.securityContext.runAsUser)
                 ) &&
                 (
-                  has(object.spec.jobTemplate.spec.securityContext) &&
-                  has(object.spec.jobTemplate.spec.securityContext.runAsUser) &&
-                  object.spec.jobTemplate.spec.securityContext.runAsUser != 0
+                  has(object.spec.jobTemplate.spec.template.spec.securityContext) &&
+                  has(object.spec.jobTemplate.spec.template.spec.securityContext.runAsUser) &&
+                  object.spec.jobTemplate.spec.template.spec.securityContext.runAsUser != 0
                 )
               )
             )

--- a/controls/C-0055/policy.yaml
+++ b/controls/C-0055/policy.yaml
@@ -42,7 +42,7 @@ spec:
     - expression: >
         object.kind != 'CronJob' ||
         (has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
-        (has(object.spec.jobTemplate.spec.securityContext) && (has(object.spec.jobTemplate.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.securityContext.seLinuxOptions))) ||
+        (has(object.spec.jobTemplate.spec.template.spec.securityContext) && (has(object.spec.jobTemplate.spec.template.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions))) ||
         object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||
         (has(container.securityContext.capabilities) && has(container.securityContext.capabilities.drop))))


### PR DESCRIPTION
The following issues can result in incorrect validation behaviour and are fixed in this PR:

1. (C-0013) `allowPrivilegeEscalation` does not exist on the `PodSecurityContext`.
2. (C-0013, C-0055) In case of CronJobs, the `PodSecurityContext` is not found at `object.spec.jobTemplate.spec.securityContext` but `object.spec.jobTemplate.spec.template.spec.securityContext`.

---

- _I also refactored `C-0013`, removing duplicate expressions._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CronJob security-context validation to reference the proper template path, ensuring accurate policy enforcement.

* **Improvements**
  * Consolidated and simplified container and pod security checks for more consistent validation.
  * Enhanced error messages to include resource kind and name for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->