### PR TITLE
fix(C-0078): Support Docker Hub user images and prevent registry spoofing

### DIFF
--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -30,7 +30,7 @@ spec:
         object.kind != 'Pod' ||
         object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
           (container.image.startsWith(registry + '/'))
         )))
       message: "Pods uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
@@ -38,7 +38,7 @@ spec:
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
         object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
           (container.image.startsWith(registry + '/'))
         )))
       message: "Workloads uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
@@ -46,7 +46,7 @@ spec:
         object.kind != 'CronJob' ||
         object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
           (container.image.startsWith(registry + '/'))
         )))
       message: "CronJob uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"

--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -30,23 +30,23 @@ spec:
         object.kind != 'Pod' ||
         object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.contains('/')) ||
-          (container.image.startsWith(registry))
+          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (container.image.startsWith(registry + '/'))
         )))
       message: "Pods uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
         object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.contains('/')) ||
-          (container.image.startsWith(registry))
+          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (container.image.startsWith(registry + '/'))
         )))
       message: "Workloads uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
     - expression: >
         object.kind != 'CronJob' ||
         object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
         (
-          (registry == 'docker.io' && !container.image.contains('/')) ||
-          (container.image.startsWith(registry))
+          (registry == 'docker.io' && !container.image.split('/')[0].contains('.')) ||
+          (container.image.startsWith(registry + '/'))
         )))
       message: "CronJob uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"

--- a/controls/C-0078/tests.json
+++ b/controls/C-0078/tests.json
@@ -94,6 +94,30 @@
         ]
     },
     {
+        "name": "Pod with local registry with port (localhost:5000/image) is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=localhost:5000/my-image"
+        ]
+    },
+    {
+        "name": "Pod with official docker.io image with tag is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].image=alpine:latest"
+        ]
+    },
+    {
+        "name": "Pod with localhost registry (no port) is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=localhost/my-image"
+        ]
+    },
+    {
         "name": "Deployment with docker.io user image (username/image) is allowed",
         "template": "deployment.yaml",
         "expected": "pass",
@@ -123,6 +147,30 @@
         "expected": "fail",
         "field_change_list": [
             "spec.template.spec.containers.[0].image=.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Deployment with local registry with port (localhost:5000/image) is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=localhost:5000/my-image"
+        ]
+    },
+    {
+        "name": "Deployment with official docker.io image with tag is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=alpine:latest"
+        ]
+    },
+    {
+        "name": "Deployment with localhost registry (no port) is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=localhost/my-image"
         ]
     }
 ]

--- a/controls/C-0078/tests.json
+++ b/controls/C-0078/tests.json
@@ -60,5 +60,69 @@
         "field_change_list": [
             "spec.template.spec.containers.[0].image=docker.io/alpine"
         ]
+    },
+    {
+        "name": "Pod with docker.io user image (username/image) is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].image=bitnami/elasticsearch"
+        ]
+    },
+    {
+        "name": "Pod with spoofed docker.io domain is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=docker.io.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Pod with spoofed gcr.io domain is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=gcr.io.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Pod with image starting with a dot is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Deployment with docker.io user image (username/image) is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=bitnami/elasticsearch"
+        ]
+    },
+    {
+        "name": "Deployment with spoofed docker.io domain is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=docker.io.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Deployment with spoofed gcr.io domain is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=gcr.io.evil.com/malware"
+        ]
+    },
+    {
+        "name": "Deployment with image starting with a dot is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=.evil.com/malware"
+        ]
     }
 ]


### PR DESCRIPTION
Fixes #70

## Problem

The current C-0078 policy has two bugs when validating image registries:

1. **Docker Hub user images blocked**: `docker.io` in `imageRepositoryAllowList` only allows official images (e.g. `nginx`) but not user-namespaced images (e.g. `bitnami/elasticsearch`). Other registries like `ghcr.io` work correctly with a single allowlist entry.

2. **Registry domain spoofing**: The `startsWith(registry)` check allows spoofed domains like `gcr.io.evil.com/malware` to pass when `gcr.io` is in the allowlist.

## Fix

- Replaced the Docker Hub detection heuristic with Docker's canonical algorithm from [distribution/reference](https://github.com/distribution/reference): a first segment is treated as a registry hostname if it contains a dot, a colon, or equals `localhost`. Everything else is a Docker Hub image reference.
- Changed `startsWith(registry)` to `startsWith(registry + '/') 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved image validation to correctly identify Docker Hub images in various formats and prevent unauthorized registry domain spoofing.

## Tests
* Added test cases covering Docker Hub user-scoped images, spoofed domain detection, images with leading dots, and localhost registry handling with and without port numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->