### PR TITLE
C-0001: normalize image registries before deny matching

### DIFF
--- a/controls/C-0001/policy.yaml
+++ b/controls/C-0001/policy.yaml
@@ -36,11 +36,12 @@ spec:
     - expression: >
         variables.containers.all(container, params.settings.untrustedRegistries.all(registry,
         !(
-          ((registry == 'docker.io' || registry == 'docker.io/') &&
+          ((registry in ['docker.io', 'docker.io/', 'index.docker.io', 'index.docker.io/', 'registry-1.docker.io', 'registry-1.docker.io/']) &&
             (!container.image.contains('/') ||
               (!container.image.split('/')[0].contains('.') &&
                !container.image.split('/')[0].contains(':') &&
-               container.image.split('/')[0] != 'localhost'))) ||
+               container.image.split('/')[0] != 'localhost') ||
+              container.image.split('/')[0] in ['docker.io', 'index.docker.io', 'registry-1.docker.io'])) ||
           container.image.startsWith(registry.endsWith('/') ? registry : registry + '/')
         )))
       messageExpression: 'object.kind + "/" + object.metadata.name + " uses an image from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"'

--- a/controls/C-0001/policy.yaml
+++ b/controls/C-0001/policy.yaml
@@ -25,10 +25,22 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod' ? object.spec.containers
+        : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'] ? object.spec.template.spec.containers
+        : object.kind == 'CronJob' ? object.spec.jobTemplate.spec.template.spec.containers
+        : []
+      name: containers
   validations:
-    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))"
-      message: "Pods uses an image from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"
-    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))"
-      message: "Workloads uses an image from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"
-    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.untrustedRegistries.all(registry,!container.image.startsWith(registry)))"
-      message: "CronJob uses an image from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"
+    - expression: >
+        variables.containers.all(container, params.settings.untrustedRegistries.all(registry,
+        !(
+          ((registry == 'docker.io' || registry == 'docker.io/') &&
+            (!container.image.contains('/') ||
+              (!container.image.split('/')[0].contains('.') &&
+               !container.image.split('/')[0].contains(':') &&
+               container.image.split('/')[0] != 'localhost'))) ||
+          container.image.startsWith(registry.endsWith('/') ? registry : registry + '/')
+        )))
+      messageExpression: 'object.kind + "/" + object.metadata.name + " uses an image from a forbidden registry! (see more at https://kubescape.io/docs/controls/c-0001/)"'

--- a/controls/C-0001/tests.json
+++ b/controls/C-0001/tests.json
@@ -40,6 +40,22 @@
         ]
     },
     {
+        "name": "Pod with index.docker.io Docker Hub alias is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=index.docker.io/library/nginx"
+        ]
+    },
+    {
+        "name": "Pod with registry-1.docker.io Docker Hub alias is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=registry-1.docker.io/library/nginx"
+        ]
+    },
+    {
         "name": "Pod with registry prefix spoofing is not matched as docker.io",
         "template": "pod.yaml",
         "expected": "pass",

--- a/controls/C-0001/tests.json
+++ b/controls/C-0001/tests.json
@@ -8,10 +8,43 @@
         ]
     },
     {
-        "name": "Pod without image from quay.io is allowed",
+        "name": "Pod with image from an unlisted registry is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
+            "spec.containers.[0].image=ghcr.io/example/app:latest"
+        ]
+    },
+    {
+        "name": "Pod with implicit Docker Hub image is blocked when docker.io is forbidden",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=nginx"
+        ]
+    },
+    {
+        "name": "Pod with Docker Hub namespace image is blocked when docker.io is forbidden",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=library/nginx"
+        ]
+    },
+    {
+        "name": "Pod with explicit Docker Hub image is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].image=docker.io/library/nginx"
+        ]
+    },
+    {
+        "name": "Pod with registry prefix spoofing is not matched as docker.io",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].image=docker.io.evil.com/nginx"
         ]
     },
     {
@@ -23,10 +56,27 @@
         ]
     },
     {
-        "name": "CronJob without image from quay.io is allowed",
+        "name": "CronJob with image from an unlisted registry is allowed",
         "template": "cronjob.yaml",
         "expected": "pass",
         "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].image=ghcr.io/example/app:latest"
+        ]
+    },
+    {
+        "name": "CronJob with implicit Docker Hub image is blocked when docker.io is forbidden",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].image=busybox:1.35"
+        ]
+    },
+    {
+        "name": "CronJob with gcr.io prefix spoofing is not matched as gcr.io",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].image=gcr.io.evil.com/app:latest"
         ]
     }
 ]


### PR DESCRIPTION
### Summary

This PR fixes C-0001 so registry-less Docker Hub images are evaluated against `docker.io` entries in `untrustedRegistries`. Today the policy only checks `container.image.startsWith(registry)`, so `image: nginx` bypasses a `docker.io` deny configuration.

Fixes #90 
### Changes

- Add CEL logic that derives the image registry before matching.
- Treat images without an explicit registry host as Docker Hub.
- Treat one-segment image names as Docker Hub library images.
- Match registry boundaries with `registry + '/'` to avoid spoofed domains such as `docker.io.evil.com`.
- Apply the same helper expression to Pod, workload template, and CronJob paths.
- Add regression tests for explicit and implicit Docker Hub images plus spoofed registry names.

### Testing

```bash
cd controls/C-0001
python ../../scripts/run-control-tests.py
```

Regression cases:

```yaml
image: nginx
```

```yaml
image: library/nginx
```

```yaml
image: docker.io.evil.com/nginx
```

### Why this is safe

The change only affects how the image registry is derived before applying the configured deny list. Users who already deny `docker.io` get the behavior Kubernetes image resolution implies. The explicit registry path continues to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container registry validation to reliably detect Docker Hub (including common aliases and variants), block implicit/namespace/explicit Docker Hub images when forbidden, and prevent evasion via registry-prefix spoofing. Messaging standardized to reference a "forbidden registry."

* **Refactor**
  * Merged separate resource-specific registry checks into a single, unified validation to ensure consistent enforcement across all resource types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/cel-admission-library/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->