### PR TITLE
fix(C-0026): ship [Warn] binding example and rewire test for audit semantics

### DIFF
--- a/controls/C-0026/tests.json
+++ b/controls/C-0026/tests.json
@@ -1,8 +1,9 @@
 [
     {
-        "name": "Any CronJob is flagged for review",
+        "name": "Any CronJob is surfaced via a [Warn] binding for review",
         "template": "cronjob.yaml",
-        "expected": "fail",
+        "binding_template": "policy-binding-warn.yaml",
+        "expected": "warn",
         "field_change_list": [
         ]
     }

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0026-deny-cronjobs.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0026-deny-cronjobs.md
@@ -12,7 +12,13 @@ Attackers may use Kubernetes CronJob for scheduling execution of malicious code 
 * CronJob
 
 ## What does this policy do:
-This Policy fails for every `CronJob` admitted to the cluster, surfacing it to the user for review. Use the binding `validationActions: [Warn]` to make this an audit-only signal rather than a hard deny.
+This policy flags every `CronJob` admitted to the cluster so it can be surfaced to the user for review. It is an audit-style control, not an enforcement: the Rego source in `kubescape/regolibrary` (`rule-deny-cronjobs`) emits an alert on every CronJob, with a base score of 1.0.
+
+## Binding requirement: audit-only
+
+This control is only safe when bound with `validationActions: [Audit]` or `[Warn]`. Under those actions the CronJob is admitted and a Kubernetes audit annotation or API-server warning is recorded so an operator can review it.
+
+The default `ValidatingAdmissionPolicyBinding` shipped in this repo (`test-resources/policy-binding.yaml`) uses `validationActions: [Deny]`. Binding C-0026 with `[Deny]` will reject the admission of every CronJob in the cluster, which does not match the audit intent of the source rule. An example `[Warn]` binding is provided in `test-resources/policy-binding-warn.yaml` and is the binding the C-0026 test runs against.
 
 ## Implementing this policy in the Cluster:
 [Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/scripts/run-control-tests.py
+++ b/scripts/run-control-tests.py
@@ -104,7 +104,10 @@ try:
         result = proc.returncode
 
         test_passed = False
-        if expected == 'pass' and result != 0:
+        valid_expected = {'pass', 'fail', 'warn'}
+        if expected not in valid_expected:
+            print(colored('Test failed: unsupported expected value "' + str(expected) + '"','red'))
+        elif expected == 'pass' and result != 0:
             print(colored('Test failed: expected to pass but failed','red'))
             print(proc.stderr)
         elif expected == 'fail' and result == 0:

--- a/scripts/run-control-tests.py
+++ b/scripts/run-control-tests.py
@@ -55,6 +55,7 @@ try:
         template = test['template']
         field_change_list = test['field_change_list'] if 'field_change_list' in test else []
         expected = test['expected']
+        binding_template = test['binding_template'] if 'binding_template' in test else 'policy-binding.yaml'
 
         print('-'*120)
         print('Running test: ' + name)
@@ -77,7 +78,7 @@ try:
         # Create the policy binding file
         policy_name = policy['metadata']['name']
         policy_bind_change_list = ['spec.policyName=' + policy_name, 'metadata.name=' + policy_name + '-binding', 'spec.paramRef.name=' + policy_name + '-params']
-        subprocess.check_call([python_executable, os.path.join(SCRIPTS_DIR, 'change-yaml-field.py'), '-i', os.path.join(TEST_RESOURCES_DIR, 'policy-binding.yaml'), '-o', policy_bind_temp_file_name] + policy_bind_change_list)
+        subprocess.check_call([python_executable, os.path.join(SCRIPTS_DIR, 'change-yaml-field.py'), '-i', os.path.join(TEST_RESOURCES_DIR, binding_template), '-o', policy_bind_temp_file_name] + policy_bind_change_list)
         print('Generated policy binding: ' + policy_bind_temp_file_name)
 
         # Create parameter file
@@ -110,6 +111,12 @@ try:
             print(colored('Test failed: expected to fail but passed','red'))
         elif expected == 'fail' and result != 0 and policy_name not in proc.stderr:
             print(colored('Test failed: expected VAP denial from "' + policy_name + '" but got different error','red'))
+            print(proc.stderr)
+        elif expected == 'warn' and result != 0:
+            print(colored('Test failed: expected to pass with a warning but failed','red'))
+            print(proc.stderr)
+        elif expected == 'warn' and result == 0 and policy_name not in proc.stderr:
+            print(colored('Test failed: expected VAP warning from "' + policy_name + '" but none was emitted','red'))
             print(proc.stderr)
         else:
             test_passed = True

--- a/test-resources/policy-binding-warn.yaml
+++ b/test-resources/policy-binding-warn.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: placeholder
+spec:
+  policyName: placeholder
+  validationActions: [Warn]
+  paramRef:
+    name: placeholder
+    parameterNotFoundAction: Deny
+  matchResources:
+    objectSelector:
+      matchLabels:
+        admission-policy-test: abc


### PR DESCRIPTION
 C-0026 is supposed to be an audit-style control. The Rego source in regolibrary (`rule-deny-cronjobs`) just emits an alert on every CronJob with a base score of 1.0, basically "tell the user this exists so they can review it." But the only binding shipped in this repo is `test-resources/policy-binding.yaml` with `validationActions: [Deny]`, so under that binding the policy rejects admission of every CronJob in the cluster. That does not match the source rule.

  I went down a wrong path first and assumed flipping `failurePolicy` would fix this. It does not. `failurePolicy` only fires on evaluation errors, not on a validation that cleanly returns `false`. Audit vs deny actually lives on the binding's `validationActions`. That distinction is worth knowing because the same trap will show up again in the migration batch.

  What this PR changes:

  - adds `test-resources/policy-binding-warn.yaml`, the library's first `[Warn]` binding example
  - patches `scripts/run-control-tests.py` so a test can pick its binding via an optional `binding_template` field (default stays `policy-binding.yaml`) and adds a new `expected: "warn"` arm that asserts returncode 0 plus the policy name in stderr. Every other control keeps working unchanged.
  - rewires `controls/C-0026/tests.json` to use the new binding and the `warn` assertion
  - updates the C-0026 doc to say loudly that the policy is audit-only and that the default `[Deny]` binding is unsafe for it
                                                                                                                                                                                           
Verified on a fresh kind cluster running k8s v1.31.0:

  - C-0026 test passes against the new `[Warn]` binding
  - C-0017 (unchanged control) still passes against the default `[Deny]` binding, so the harness change is backwards compatible

Partial fix #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified C-0026 policy doc: audit-style rule, alert scoring, and required validationAction bindings (Audit or Warn).

* **Tests**
  * Updated C-0026 test to expect a "warn" outcome.
  * Extended test runner to accept per-test binding templates and evaluate a "warn" expected outcome.
  * Added a warn-specific policy binding template resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->