### PR TITLE
fix(c-0055): guard the optional template.metadata before reading annotations

### DIFF
--- a/controls/C-0055/policy.yaml
+++ b/controls/C-0055/policy.yaml
@@ -33,7 +33,7 @@ spec:
       message: "Pods could have more security hardening! (see more at https://kubescape.io/docs/controls/c-0055/)"
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
-        (has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
+        (has(object.spec.template.metadata) && has(object.spec.template.metadata.annotations) && object.spec.template.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
         (has(object.spec.template.spec.securityContext) && (has(object.spec.template.spec.securityContext.seccompProfile) || has(object.spec.template.spec.securityContext.seLinuxOptions))) ||
         object.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||
@@ -41,7 +41,7 @@ spec:
       message: "Workloads could have more security hardening! (see more at https://kubescape.io/docs/controls/c-0055/)"
     - expression: >
         object.kind != 'CronJob' ||
-        (has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
+        (has(object.spec.jobTemplate.metadata) && has(object.spec.jobTemplate.metadata.annotations) && object.spec.jobTemplate.metadata.annotations.exists(annotation, annotation.startsWith("container.apparmor.security.beta.kubernetes.io"))) ||
         (has(object.spec.jobTemplate.spec.template.spec.securityContext) && (has(object.spec.jobTemplate.spec.template.spec.securityContext.seccompProfile) || has(object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions))) ||
         object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.securityContext) && (has(container.securityContext.seccompProfile) ||
         has(container.securityContext.seLinuxOptions) ||


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

C-0055's Workload and CronJob validations guard `template.metadata.annotations` with a single `has()`, which does not protect the optional `metadata` hop above it — so a manifest omitting `spec.template.metadata` / `spec.jobTemplate.metadata` makes the expression raise `no such key: metadata`. This adds the missing guard per hop. No-op at live admission; it fixes offline evaluators like the kubescape scan, which otherwise report the resource as `Skipped/Unknown`.

## What

C-0055's Workload and CronJob validations read

```
has(object.spec.template.metadata.annotations)
has(object.spec.jobTemplate.metadata.annotations)
```

`has()` only guards the *final* selection. `has(a.b.c)` still raises `no such key: b` when `a.b` is absent — so a single `has()` on `.annotations` does not protect the `.metadata` hop above it.

Both `spec.template.metadata` and `spec.jobTemplate.metadata` are optional, and a CronJob manifest very commonly omits `jobTemplate.metadata` entirely.

This adds the missing guard per hop.

## Impact

**None at live admission.** The object there is schema-defaulted, so `metadata` always exists and the expression never reaches the error. That's why this has gone unnoticed and why the test harness can't reproduce it — it evaluates against a real cluster.

It matters for consumers that evaluate these policies against **raw manifests**, where there is no defaulting. The kubescape scan does exactly that (`core/pkg/opaprocessor/cel`): the eval error is recorded as an unknown verdict and the resource is reported `Skipped/Unknown` rather than getting a real pass/fail.

## Verification

Built the v1 bundle the way the release workflow does (`kubectl kustomize apis/k8s-v1/`) and evaluated it against minimal Pod / Deployment / Job / CronJob objects that set nothing optional.

Before:

```
EVAL-ERROR C-0055 on Deployment validation[1]: eval: no such key: metadata
EVAL-ERROR C-0055 on Job        validation[1]: eval: no such key: metadata
EVAL-ERROR C-0055 on CronJob    validation[2]: eval: no such key: metadata
```

After: clean, across all four kinds and every control in the bundle.

## Context

Found while sweeping the whole bundle for this class of bug after kubescape/kubescape#2534 (which reported the same pattern in C-0045). C-0045, C-0048 and C-0055's `securityContext` path are already fixed on `main`; this `metadata` guard was the remaining instance.

Related: kubescape/kubescape#2535 patches the vendored v0.11 copy on the kubescape side, since the newest release predates all of these fixes. **A release past v0.11 would let that patch be dropped in favour of a clean version bump** — worth cutting one once this lands.

AI-skills: none