### PR TITLE
fix: use messageExpression for CEL message bodies in C-0013, C-0198, C-0210

### DIFF
--- a/controls/C-0013/policy.yaml
+++ b/controls/C-0013/policy.yaml
@@ -76,4 +76,4 @@ spec:
             )
           )
         )
-      message: object.kind + "/" + object.metadata.name + " contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"
+      messageExpression: object.kind + "/" + object.metadata.name + " contains container/s which have the capability to run as root! (see more at https://kubescape.io/docs/controls/c-0013/)"

--- a/controls/C-0198/policy.yaml
+++ b/controls/C-0198/policy.yaml
@@ -51,5 +51,5 @@ spec:
                 : -1)
           ) != 0
         )
-      message: >
+      messageExpression: >
         object.kind + '/' + object.metadata.name + ' has a container explicitly running as root (UID 0). (see more at https://kubescape.io/docs/controls/c-0198/)'

--- a/controls/C-0210/policy.yaml
+++ b/controls/C-0210/policy.yaml
@@ -51,5 +51,5 @@ spec:
                 : 'Unconfined')
           ) != 'Unconfined'
         )
-      message: >
+      messageExpression: >
         object.kind + '/' + object.metadata.name + ' has a container with seccomp profile Unconfined or undefined. (see more at https://kubescape.io/docs/controls/c-0210/)'


### PR DESCRIPTION
## What

`message` is emitted verbatim by ValidatingAdmissionPolicy; only `messageExpression` is evaluated by CEL. C-0013, C-0198 and C-0210 set `message` to a CEL string concatenation instead, so a violation on any of them shows the literal, unevaluated expression — e.g. `object.kind + "/" + object.metadata.name + " contains container/s which have the capability to run as root! ..."` — instead of a message naming the actual resource.

Sibling controls already use `messageExpression` for the same pattern (e.g. C-0012, C-0268), so these three now match.

## Found via

Flagged by CodeRabbit reviewing kubescape/kubescape#2535, confirmed by sweeping the whole bundle for the same mistake — these three are the only instances.

## Downstream

kubescape/kubescape has applied the same fix as a local hand-patch on its vendored copy ahead of a release carrying this change (documented in `core/pkg/opaprocessor/cel/vapdata/README.md`, with a regression test guarding it). Once this lands in a release and `CEL_LIBRARY_VERSION` is bumped there, that local patch gets deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling by generating denial messages dynamically from the affected resource.
  * Preserved existing validation logic and message content while ensuring messages accurately reflect the admission object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->