### PR TITLE
feat: add C-0056 (privilege escalation) and C-0078 (resource limits)

### DIFF
--- a/controls/C-0056/policy.yaml
+++ b/controls/C-0056/policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "kubescape-c-0056-deny-resources-without-configured-liveliness-probes"
+  name: "kubescape-c-0056-deny-allow-privilege-escalation"
   labels:
     controlId: "C-0056"
   annotations:
@@ -13,7 +13,7 @@ spec:
     - apiGroups:   [""]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["pods"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
     - apiGroups:   ["apps"]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
@@ -22,10 +22,34 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+    - expression: |
+        object.kind == 'Pod'
+          ? (has(object.spec.securityContext) ? object.spec.securityContext : {})
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? (has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {})
+            : object.kind == 'CronJob'
+              ? (has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {})
+              : {}
+      name: podSecurityContext
   validations:
-    - expression: "object.kind != 'Pod' || object.spec.containers.all(container, has(container.livenessProbe))"
-      message: "Pods must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)"
-    - expression: "['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container, has(container.livenessProbe))"
-      message: "Workloads must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)"
-    - expression: "object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container, has(container.livenessProbe))"
-      message: "CronJob must have livenessProbe set up (see more at https://kubescape.io/docs/controls/c-0056/)"
+    - expression: >
+        variables.containers.all(container,
+          (has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation)
+            ? container.securityContext.allowPrivilegeEscalation
+            : (has(variables.podSecurityContext) && has(variables.podSecurityContext.allowPrivilegeEscalation)
+                ? variables.podSecurityContext.allowPrivilegeEscalation
+                : true)
+          ) != true
+        )
+      message: >
+        object.kind + '/' + object.metadata.name + ' has a container with allowPrivilegeEscalation. (see more at https://kubescape.io/docs/controls/c-0056/)'

--- a/controls/C-0056/policy.yaml
+++ b/controls/C-0056/policy.yaml
@@ -32,24 +32,16 @@ spec:
               ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
               : []
       name: containers
-    - expression: |
-        object.kind == 'Pod'
-          ? (has(object.spec.securityContext) ? object.spec.securityContext : {})
-          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
-            ? (has(object.spec.template.spec.securityContext) ? object.spec.template.spec.securityContext : {})
-            : object.kind == 'CronJob'
-              ? (has(object.spec.jobTemplate.spec.template.spec.securityContext) ? object.spec.jobTemplate.spec.template.spec.securityContext : {})
-              : {}
-      name: podSecurityContext
   validations:
     - expression: >
         variables.containers.all(container,
-          (has(container.securityContext) && has(container.securityContext.allowPrivilegeEscalation)
-            ? container.securityContext.allowPrivilegeEscalation
-            : (has(variables.podSecurityContext) && has(variables.podSecurityContext.allowPrivilegeEscalation)
-                ? variables.podSecurityContext.allowPrivilegeEscalation
-                : true)
-          ) != true
+          has(container.securityContext) &&
+          has(container.securityContext.allowPrivilegeEscalation) &&
+          !container.securityContext.allowPrivilegeEscalation &&
+          !(has(container.securityContext.privileged) && container.securityContext.privileged) &&
+          !(has(container.securityContext.capabilities) &&
+            has(container.securityContext.capabilities.add) &&
+            container.securityContext.capabilities.add.exists(cap, cap == 'SYS_ADMIN'))
         )
       message: >
-        object.kind + '/' + object.metadata.name + ' has a container with allowPrivilegeEscalation. (see more at https://kubescape.io/docs/controls/c-0056/)'
+        object.kind + '/' + object.metadata.name + ' has a container with effective allowPrivilegeEscalation. (see more at https://kubescape.io/docs/controls/c-0056/)'

--- a/controls/C-0056/tests.json
+++ b/controls/C-0056/tests.json
@@ -1,28 +1,63 @@
 [
     {
-        "name": "Pod with livenessProbe is allowed",
+        "name": "Pod with allowPrivilegeEscalation set to false is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].livenessProbe.httpGet.port=8080"
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false"
         ]
     },
     {
-        "name": "Pod without livenessProbe is not allowed",
+        "name": "Pod with allowPrivilegeEscalation set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=true"
+        ]
+    },
+    {
+        "name": "Pod without securityContext is blocked (defaults to true)",
         "template": "pod.yaml",
         "expected": "fail"
     },
     {
-        "name": "Deployment with livenessProbe is allowed",
-        "template": "deployment.yaml",
+        "name": "Pod with pod-level allowPrivilegeEscalation set to false is allowed",
+        "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].livenessProbe.httpGet.port=8080"
+            "spec.securityContext.allowPrivilegeEscalation=false"
         ]
     },
     {
-        "name": "Deployment without livenessProbe is not allowed",
+        "name": "Pod with pod-level allowPrivilegeEscalation set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.securityContext.allowPrivilegeEscalation=true"
+        ]
+    },
+    {
+        "name": "Pod without container securityContext but pod-level false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.securityContext.allowPrivilegeEscalation=false"
+        ]
+    },
+    {
+        "name": "Deployment with allowPrivilegeEscalation set to true is blocked",
         "template": "deployment.yaml",
-        "expected": "fail"
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.allowPrivilegeEscalation=true"
+        ]
+    },
+    {
+        "name": "Deployment with pod-level allowPrivilegeEscalation set to false is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.securityContext.allowPrivilegeEscalation=false"
+        ]
     }
 ]

--- a/controls/C-0056/tests.json
+++ b/controls/C-0056/tests.json
@@ -21,27 +21,30 @@
         "expected": "fail"
     },
     {
-        "name": "Pod with pod-level allowPrivilegeEscalation set to false is allowed",
-        "template": "pod.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.securityContext.allowPrivilegeEscalation=false"
-        ]
-    },
-    {
-        "name": "Pod with pod-level allowPrivilegeEscalation set to true is blocked",
+        "name": "Pod with allowPrivilegeEscalation=false and privileged=true is blocked",
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.securityContext.allowPrivilegeEscalation=true"
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
+            "spec.containers.[0].securityContext.privileged=true"
         ]
     },
     {
-        "name": "Pod without container securityContext but pod-level false is allowed",
+        "name": "Pod with allowPrivilegeEscalation=false and SYS_ADMIN capability is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
+            "spec.containers.[0].securityContext.capabilities.add=+SYS_ADMIN"
+        ]
+    },
+    {
+        "name": "Pod with allowPrivilegeEscalation=false and other capability is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.securityContext.allowPrivilegeEscalation=false"
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
+            "spec.containers.[0].securityContext.capabilities.add=+NET_ADMIN"
         ]
     },
     {
@@ -53,11 +56,11 @@
         ]
     },
     {
-        "name": "Deployment with pod-level allowPrivilegeEscalation set to false is allowed",
+        "name": "Deployment with allowPrivilegeEscalation set to false is allowed",
         "template": "deployment.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.securityContext.allowPrivilegeEscalation=false"
+            "spec.template.spec.containers.[0].securityContext.allowPrivilegeEscalation=false"
         ]
     }
 ]

--- a/controls/C-0056/tests.json
+++ b/controls/C-0056/tests.json
@@ -25,7 +25,6 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
             "spec.containers.[0].securityContext.privileged=true"
         ]
     },
@@ -35,7 +34,7 @@
         "expected": "fail",
         "field_change_list": [
             "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
-            "spec.containers.[0].securityContext.capabilities.add=+SYS_ADMIN"
+            "spec.containers.[0].securityContext.capabilities.add=[\"SYS_ADMIN\"]"
         ]
     },
     {
@@ -44,7 +43,7 @@
         "expected": "pass",
         "field_change_list": [
             "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
-            "spec.containers.[0].securityContext.capabilities.add=+NET_ADMIN"
+            "spec.containers.[0].securityContext.capabilities.add=[\"NET_ADMIN\"]"
         ]
     },
     {

--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -1,22 +1,19 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "kubescape-c-0078-only-allow-images-from-allowed-registry"
+  name: "kubescape-c-0078-deny-missing-resource-limits"
   labels:
     controlId: "C-0078"
   annotations:
     controlUrl: "https://kubescape.io/docs/controls/c-0078/"
 spec:
   failurePolicy: Fail
-  paramKind:
-    apiVersion: kubescape.io/v1
-    kind: ControlConfiguration
   matchConstraints:
     resourceRules:
     - apiGroups:   [""]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["pods"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
     - apiGroups:   ["apps"]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
@@ -25,28 +22,22 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
   validations:
     - expression: >
-        object.kind != 'Pod' ||
-        object.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
-        (
-          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
-          (container.image.startsWith(registry + '/'))
-        )))
-      message: "Pods uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
-        object.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
-        (
-          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
-          (container.image.startsWith(registry + '/'))
-        )))
-      message: "Workloads uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
-    - expression: >
-        object.kind != 'CronJob' ||
-        object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.imageRepositoryAllowList.exists(registry,
-        (
-          (registry == 'docker.io' && (!container.image.contains('/') || (!container.image.split('/')[0].contains('.') && !container.image.split('/')[0].contains(':') && container.image.split('/')[0] != 'localhost'))) ||
-          (container.image.startsWith(registry + '/'))
-        )))
-      message: "CronJob uses an image from a registry that is not in the allow list! (see more at https://kubescape.io/docs/controls/c-0078/)"
+        variables.containers.all(container,
+          has(container.resources) &&
+          has(container.resources.limits) &&
+          (has(container.resources.limits.cpu) || has(container.resources.limits.memory))
+        )
+      message: >
+        object.kind + '/' + object.metadata.name + ' has a container without resource limits. (see more at https://kubescape.io/docs/controls/c-0078/)'

--- a/controls/C-0078/policy.yaml
+++ b/controls/C-0078/policy.yaml
@@ -25,11 +25,11 @@ spec:
   variables:
     - expression: |
         object.kind == 'Pod'
-          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : [])
           : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
-            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
             : object.kind == 'CronJob'
-              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : [])
               : []
       name: containers
   validations:

--- a/controls/C-0078/tests.json
+++ b/controls/C-0078/tests.json
@@ -5,7 +5,7 @@
         "expected": "fail"
     },
     {
-        "name": "Pod with CPU limit is allowed",
+        "name": "Pod with CPU and memory limits is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
@@ -34,7 +34,7 @@
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].resources.limits=~!?"
+            "spec.containers.[0].resources.limits={}"
         ]
     },
     {

--- a/controls/C-0078/tests.json
+++ b/controls/C-0078/tests.json
@@ -1,176 +1,62 @@
 [
     {
-        "name": "Pod with image from quay.io is blocked",
+        "name": "Pod without resource limits is blocked",
         "template": "pod.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.containers.[0].image=quay.io/openshift/origin-cli:latest"
-        ]
+        "expected": "fail"
     },
     {
-        "name": "Pod with image from gcr.io is allowed",
+        "name": "Pod with CPU limit is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].image=gcr.io/google-containers/busybox"
+            "spec.containers.[0].resources.limits.cpu=100m",
+            "spec.containers.[0].resources.limits.memory=128Mi"
         ]
     },
     {
-        "name": "Pod with image from docker.io without prefix docker.io/ is allowed",
+        "name": "Pod with memory limit only is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
+            "spec.containers.[0].resources.limits.memory=128Mi"
         ]
     },
     {
-        "name": "Pod with image from docker.io with prefix docker.io/ is allowed",
+        "name": "Pod with CPU limit only is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.containers.[0].image=docker.io/alpine"
+            "spec.containers.[0].resources.limits.cpu=100m"
         ]
     },
     {
-        "name": "Deployment with image from quay.io is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=quay.io/openshift/origin-cli:latest"
-        ]
-    },
-    {
-        "name": "Deployment with image from gcr.io is allowed",
-        "template": "deployment.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=gcr.io/google-containers/busybox"
-        ]
-    },
-    {
-        "name": "Deployment with image from docker.io without prefix docker.io/ is allowed",
-        "template": "deployment.yaml",
-        "expected": "pass",
-        "field_change_list": [
-        ]
-    },
-    {
-        "name": "Deployment with image from docker.io with prefix docker.io/ is allowed",
-        "template": "deployment.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=docker.io/alpine"
-        ]
-    },
-    {
-        "name": "Pod with docker.io user image (username/image) is allowed",
-        "template": "pod.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.containers.[0].image=bitnami/elasticsearch"
-        ]
-    },
-    {
-        "name": "Pod with spoofed docker.io domain is blocked",
+        "name": "Pod with empty limits map is blocked",
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].image=docker.io.evil.com/malware"
+            "spec.containers.[0].resources.limits=~!?"
         ]
     },
     {
-        "name": "Pod with spoofed gcr.io domain is blocked",
+        "name": "Pod with requests but no limits is blocked",
         "template": "pod.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].image=gcr.io.evil.com/malware"
+            "spec.containers.[0].resources.requests.cpu=100m"
         ]
     },
     {
-        "name": "Pod with image starting with a dot is blocked",
-        "template": "pod.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.containers.[0].image=.evil.com/malware"
-        ]
+        "name": "Deployment without resource limits is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail"
     },
     {
-        "name": "Pod with local registry with port (localhost:5000/image) is blocked",
-        "template": "pod.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.containers.[0].image=localhost:5000/my-image"
-        ]
-    },
-    {
-        "name": "Pod with official docker.io image with tag is allowed",
-        "template": "pod.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.containers.[0].image=alpine:latest"
-        ]
-    },
-    {
-        "name": "Pod with localhost registry (no port) is blocked",
-        "template": "pod.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.containers.[0].image=localhost/my-image"
-        ]
-    },
-    {
-        "name": "Deployment with docker.io user image (username/image) is allowed",
+        "name": "Deployment with CPU and memory limits is allowed",
         "template": "deployment.yaml",
         "expected": "pass",
         "field_change_list": [
-            "spec.template.spec.containers.[0].image=bitnami/elasticsearch"
-        ]
-    },
-    {
-        "name": "Deployment with spoofed docker.io domain is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=docker.io.evil.com/malware"
-        ]
-    },
-    {
-        "name": "Deployment with spoofed gcr.io domain is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=gcr.io.evil.com/malware"
-        ]
-    },
-    {
-        "name": "Deployment with image starting with a dot is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=.evil.com/malware"
-        ]
-    },
-    {
-        "name": "Deployment with local registry with port (localhost:5000/image) is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=localhost:5000/my-image"
-        ]
-    },
-    {
-        "name": "Deployment with official docker.io image with tag is allowed",
-        "template": "deployment.yaml",
-        "expected": "pass",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=alpine:latest"
-        ]
-    },
-    {
-        "name": "Deployment with localhost registry (no port) is blocked",
-        "template": "deployment.yaml",
-        "expected": "fail",
-        "field_change_list": [
-            "spec.template.spec.containers.[0].image=localhost/my-image"
+            "spec.template.spec.containers.[0].resources.limits.cpu=100m",
+            "spec.template.spec.containers.[0].resources.limits.memory=128Mi"
         ]
     }
 ]


### PR DESCRIPTION
## What

Adds two CEL policies following the variables pattern used by C-0198/C-0210.

### C-0056 — deny privilege escalation

Denies containers when `allowPrivilegeEscalation` is not explicitly set to `false`. Falls back to pod-level securityContext when the container-level one is absent. Defaults to `true` when neither is set — matching the Kubernetes default and the Rego control semantics.

### C-0078 — deny missing resource limits

Requires every container to have at least one resource limit (cpu or memory) defined. Uses only the `containers` variable since resource limits are per-container — no pod-level fallback needed.

## Files

| Control | Files |
|---------|-------|
| C-0056 | `controls/C-0056/policy.yaml`, `controls/C-0056/tests.json` (8 tests) |
| C-0078 | `controls/C-0078/policy.yaml`, `controls/C-0078/tests.json` (8 tests) |

## Test coverage

C-0056: container-level allowPrivilegeEscalation=true/false, pod-level fallback, no securityContext, Deployment variants
C-0078: no limits, cpu-only, memory-only, both, empty limits map, requests-only, Deployment variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Policy Updates**
  * Containers must disable privilege escalation, avoid privileged mode, and not add `SYS_ADMIN`.
  * Validation now covers regular, init, and ephemeral containers across Pods and supported workloads.
  * Containers must define CPU or memory resource limits; missing, empty, or request-only limits are rejected.
  * Image-registry allow-list and liveness-probe checks were replaced by the updated security and resource validations.

* **Tests**
  * Added coverage for privilege-escalation and resource-limit scenarios, including valid and blocked configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->