### PR TITLE
fix(C-0057): correct Linux capability typo from SYS_ADM to SYS_ADMIN

### DIFF
--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -29,7 +29,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -38,7 +38,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -47,6 +47,6 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"

--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -8,37 +8,40 @@
         ]
     },
     {
-        "name": "Pod having container with \"SYS_ADM\" capability is denied",
+        "name": "Pod having container with \"SYS_ADMIN\" capability is denied",
         "template": "pod-for-list-items.yaml",
         "expected": "fail",
         "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=SYS_ADMIN"
         ]
     },
     {
-        "name": "Pod having container having securityContext.privileged set to true and with \"SYS_ADM\" capability is denied",
+        "name": "Pod having container having securityContext.privileged set to true and with \"SYS_ADMIN\" capability is denied",
         "template": "pod-for-list-items.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.containers.[0].securityContext.privileged=true"
+            "spec.containers.[0].securityContext.privileged=true",
+            "spec.containers.[0].securityContext.capabilities.add.[0]=SYS_ADMIN"
         ]
     },
     {
-        "name": "Pod having container not having securityContext.privileged set to true and without \"SYS_ADM\" capability is allowed",
+        "name": "Pod having container not having securityContext.privileged set to true and without \"SYS_ADMIN\" capability is allowed",
         "template": "pod.yaml",
         "expected": "pass",
         "field_change_list": [
         ]
     },
     {
-        "name": "Deployment having container having securityContext.privileged set to true and with \"SYS_ADM\" capability is denied",
+        "name": "Deployment having container having securityContext.privileged set to true and with \"SYS_ADMIN\" capability is denied",
         "template": "deployment-for-list-items.yaml",
         "expected": "fail",
         "field_change_list": [
-            "spec.template.spec.containers.[0].securityContext.privileged=true"
+            "spec.template.spec.containers.[0].securityContext.privileged=true",
+            "spec.template.spec.containers.[0].securityContext.capabilities.add.[0]=SYS_ADMIN"
         ]
     },
     {
-        "name": "Deployment having container not having securityContext.privileged set to true and without \"SYS_ADM\" capability is allowed",
+        "name": "Deployment having container not having securityContext.privileged set to true and without \"SYS_ADMIN\" capability is allowed",
         "template": "deployment.yaml",
         "expected": "pass",
         "field_change_list": [

--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -46,5 +46,13 @@
         "expected": "pass",
         "field_change_list": [
         ]
+    },
+    {
+        "name": "Pod having container with a non-SYS_ADMIN capability is allowed",
+        "template": "pod-for-list-items.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=NET_ADMIN"
+        ]
     }
 ]

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0057-privileged-container-denied.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0057-privileged-container-denied.md
@@ -21,7 +21,7 @@ A privileged container is a container that has all the capabilities of the host 
 ## What does this policy do:
 This Policy checks for every container in the resource:
 * If `securityContext.privileged` is not set or set to false.
-* If `securityContext.capabilities.add` does not contain `SYS_ADM` capability.
+* If `securityContext.capabilities.add` does not contain `SYS_ADMIN` capability.
 
 . If any of the above two checks fail, the resource is denied from being deployed in the cluster.
 

--- a/runtime-policies/privileged/policy.yaml
+++ b/runtime-policies/privileged/policy.yaml
@@ -25,7 +25,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -34,7 +34,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -43,6 +43,6 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADM')))
+          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
         )
       message: "CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"


### PR DESCRIPTION
Fixes the typo in C-0057 where the Linux capability was misspelled as 'SYS_ADM' instead of 'SYS_ADMIN', causing the policy to miss a major escalation path. This updates all three CEL expression blocks in the policy. Thanks @matthyx for spotting this during the C-0016 review!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Linux capability validation for Pods, workloads, and CronJobs.
  * Resources using the `SYS_ADMIN` capability are now evaluated correctly.
  * Added coverage confirming that `NET_ADMIN` remains allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->