### PR TITLE
fix: prevent capability string casing and ALL wildcard bypass (Issue #106)

### DIFF
--- a/controls/C-0046/policy.yaml
+++ b/controls/C-0046/policy.yaml
@@ -28,22 +28,28 @@ spec:
   validations:
     - expression: >
         object.kind != 'Pod' ||
-        object.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "Pod has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
-        object.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.template.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "Workload has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"
     - expression: >
         object.kind != 'CronJob' ||
-        object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.jobTemplate.spec.template.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "CronJob has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"

--- a/controls/C-0046/tests.json
+++ b/controls/C-0046/tests.json
@@ -33,5 +33,21 @@
         "expected": "fail",
         "field_change_list": [
         ]
+    },
+    {
+        "name": "Pod having container with lowercase \"net_raw\" capability is blocked",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=net_raw"
+        ]
+    },
+    {
+        "name": "Pod having container with \"ALL\" capability is blocked",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=ALL"
+        ]
     }
 ]

--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -29,7 +29,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -38,7 +38,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -47,6 +47,6 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"

--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -54,5 +54,21 @@
         "field_change_list": [
             "spec.containers.[0].securityContext.capabilities.add.[0]=NET_ADMIN"
         ]
+    },
+    {
+        "name": "Pod having container with lowercase \"sys_admin\" capability is denied",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=sys_admin"
+        ]
+    },
+    {
+        "name": "Pod having container with \"ALL\" capability is denied",
+        "template": "pod-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=ALL"
+        ]
     }
 ]

--- a/runtime-policies/insecure-capabilities/policy.yaml
+++ b/runtime-policies/insecure-capabilities/policy.yaml
@@ -24,22 +24,28 @@ spec:
   validations:
     - expression: >
         object.kind != 'Pod' ||
-        object.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "Pod has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"
     - expression: >
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
-        object.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.template.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "Workload has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"
     - expression: >
         object.kind != 'CronJob' ||
-        object.spec.jobTemplate.spec.template.spec.containers.all(container, params.settings.insecureCapabilities.all(insecureCapability,
+        object.spec.jobTemplate.spec.template.spec.containers.all(container,
         !has(container.securityContext) || !has(container.securityContext.capabilities) || !has(container.securityContext.capabilities.add) ||
-        container.securityContext.capabilities.add.all(capability, capability != insecureCapability)
-        ))
+        (container.securityContext.capabilities.add.all(capability, capability.upperAscii() != 'ALL') &&
+        params.settings.insecureCapabilities.all(insecureCapability,
+        container.securityContext.capabilities.add.all(capability, capability.upperAscii() != insecureCapability.upperAscii())))
+        )
       message: "CronJob has one or more containers with insecure capabilities! (see more at https://kubescape.io/docs/controls/c-0046/)"

--- a/runtime-policies/privileged/policy.yaml
+++ b/runtime-policies/privileged/policy.yaml
@@ -25,7 +25,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -34,7 +34,7 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
     - expression: >
@@ -43,6 +43,6 @@ spec:
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap != 'SYS_ADMIN')))
+          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
       message: "CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"


### PR DESCRIPTION
Resolves #106.

Prevent two capability bypasses in C-0057, C-0046, and runtime-policies/privileged:

1. **Case bypass** - Convert both the incoming capability and the insecure capability list to uppercase using `upperAscii()` before comparison, so values like `sys_admin` or `net_raw` can no longer slip past.
2. **ALL wildcard bypass** - Explicitly deny the `ALL` capability string, which in Kubernetes grants every capability and was not previously caught.

### Files changed:
- `controls/C-0057/policy.yaml` - 3 expressions updated
- `controls/C-0046/policy.yaml` - 3 expressions updated
- `runtime-policies/privileged/policy.yaml` - 3 expressions updated
- `controls/C-0057/tests.json` - Added tests for lowercase `sys_admin` and `ALL`
- `controls/C-0046/tests.json` - Added tests for lowercase `net_raw` and `ALL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capability validation now treats capability names case-insensitively.
  * Pods, workloads, and CronJobs correctly reject the `ALL` capability.
  * Privileged-container checks consistently block both `SYS_ADMIN` and `ALL`, regardless of capitalization.

* **Tests**
  * Added coverage for lowercase capability names and blocked `ALL` capability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->