### PR TITLE
fix: cover initContainers and ephemeralContainers in C-0057

### DIFF
--- a/controls/C-0057/policy.yaml
+++ b/controls/C-0057/policy.yaml
@@ -13,7 +13,7 @@ spec:
     - apiGroups:   [""]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["pods"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
     - apiGroups:   ["apps"]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
@@ -22,31 +22,24 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
   validations:
     - expression: >
-        object.kind != 'Pod' || object.spec.containers.all(container,
+        variables.containers.all(container,
         !(has(container.securityContext)) ||
         (
           (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
           (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
           container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
         )
-      message: "Pod has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
-    - expression: >
-        ['Deployment','ReplicaSet','DaemonSet','StatefulSet', 'Job'].all(kind, object.kind != kind) || object.spec.template.spec.containers.all(container,
-        !(has(container.securityContext)) ||
-        (
-          (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
-          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
-        )
-      message: "Workloads has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
-    - expression: >
-        object.kind != 'CronJob' || object.spec.jobTemplate.spec.template.spec.containers.all(container,
-        !(has(container.securityContext)) ||
-        (
-          (!(has(container.securityContext.privileged)) || container.securityContext.privileged != true) &&
-          (!(has(container.securityContext.capabilities)) || !(has(container.securityContext.capabilities.add)) ||
-          container.securityContext.capabilities.add.all(cap, cap.upperAscii() != 'SYS_ADMIN' && cap.upperAscii() != 'ALL')))
-        )
-      message: "CronJob has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)"
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has one or more privileged container.(see more at https://kubescape.io/docs/controls/c-0057/)'

--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -93,5 +93,20 @@
         "expected": "pass",
         "field_change_list": [
         ]
+    },
+    {
+        "name": "Pod having initContainer with securityContext.privileged set to true is denied",
+        "template": "pod-with-init-container.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Pod having initContainer without securityContext.privileged set to true is allowed",
+        "template": "pod-with-init-container.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
     }
 ]

--- a/test-resources/pod-with-init-container.yaml
+++ b/test-resources/pod-with-init-container.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    admission-policy-test: abc
+spec:
+  initContainers:
+  - name: init
+    image: alpine
+    command: ["sh", "-c", "true"]
+  containers:
+  - name: sleep
+    image: alpine
+    command: ["sh"]
+    args: ["-c", "while true; do sleep 1; done"]


### PR DESCRIPTION
Extends C-0057 to check initContainers and ephemeralContainers, not just the main containers list. Closes #107. Uses the same variables pattern already in C-0198 and C-0210 instead of duplicating the container walk three times.

initContainers has an automated test. ephemeralContainers doesn't, since it can only be added to a running pod through the subresource, which the current test runner can't express. Verified it by hand on a real cluster instead, a privileged ephemeral container gets denied, a safe one goes through. Happy to change approach if there's a better way to get this into the automated suite.

All 12 tests in controls/C-0057 pass.

Feel free to ping me for any issues or questions!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Policy Updates**
  * Extended container security validation to include regular, init, and ephemeral containers across Pods, workloads, Jobs, and CronJobs.
  * Privileged containers and containers adding `SYS_ADMIN` are now denied consistently, with clearer resource-specific messages.

* **Validation**
  * Added coverage confirming privileged init containers are rejected while compliant init containers are allowed.
  * Added a representative Pod manifest for validating admission-policy behavior with init containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->