### PR TITLE
test: add CronJob coverage for C-0057

### DIFF
--- a/controls/C-0057/tests.json
+++ b/controls/C-0057/tests.json
@@ -70,5 +70,28 @@
         "field_change_list": [
             "spec.containers.[0].securityContext.capabilities.add.[0]=ALL"
         ]
+    },
+    {
+        "name": "CronJob having container having securityContext.privileged set to true is denied",
+        "template": "cronjob-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "CronJob having container with \"SYS_ADMIN\" capability is denied",
+        "template": "cronjob-for-list-items.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].securityContext.capabilities.add.[0]=SYS_ADMIN"
+        ]
+    },
+    {
+        "name": "CronJob having container not having securityContext.privileged set to true and without \"SYS_ADMIN\" capability is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+        ]
     }
 ]

--- a/test-resources/cronjob-for-list-items.yaml
+++ b/test-resources/cronjob-for-list-items.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: test-cronjob
+  labels:
+    admission-policy-test: abc
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: test-container
+            image: busybox:1.35
+            command:
+            - /bin/sh
+            - -c
+            - date; echo "Hello from the Kubernetes cluster"; sleep 5
+            securityContext:
+              capabilities:
+                add:
+                - CHOWN
+                drop:
+                - NET_RAW


### PR DESCRIPTION
Adds CronJob test coverage for C-0057, closes #105. The policy already applied to CronJobs, there just weren't tests for it.

New fixture, cronjob-for-list-items.yaml, based on the existing cronjob.yaml but with capabilities already populated so the SYS_ADMIN case can overwrite an existing list index. Three new tests mirror the existing Pod and Deployment ones.

All 12 tests in controls/C-0057 pass.

Feel free to ping me for any issues or questions!