### PR TITLE
fix: add missing controlId labels to C-0012 and C-0013

### DIFF
--- a/controls/C-0012/policy.yaml
+++ b/controls/C-0012/policy.yaml
@@ -2,6 +2,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0012-deny-resources-with-sensitive-information-in-environment-variables"
+  labels:
+    controlId: "C-0012"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0012/"
 spec:
   failurePolicy: Fail
   paramKind:

--- a/controls/C-0013/policy.yaml
+++ b/controls/C-0013/policy.yaml
@@ -2,6 +2,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "kubescape-c-0013-deny-resources-with-capability-to-run-as-root"
+  labels:
+    controlId: "C-0013"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0013/"
 spec:
   failurePolicy: Fail
   matchConstraints:


### PR DESCRIPTION
C-0012 and C-0013 were the only two policies in the repo without a `controlId` label. They were also the only two without the `controlUrl` annotation, so I added both to keep them in line with the other 38.

Why it matters: kubescape indexes the synced policy bundle by the `controlId` label. A policy with no label still gets indexed by name, but it never gets attached to a control, so the scan path just skips it. Same on the enforcement status side, those two controls would keep showing as not enforced even with the policy installed and bound in the cluster.

Nothing under `spec` changed, this is metadata only. `kubectl kustomize controls/` still builds and I ran the C-0012 and C-0013 test suites locally against a 1.31 cluster, both green.

Two unrelated things I noticed while doing this, I did not touch them here:

* the README row and the doc filename for C-0013 both say `kubescape-c-0013-deny-if-container-runs-as-root`, but the policy's real `metadata.name` is `kubescape-c-0013-deny-resources-with-capability-to-run-as-root`
* `docs/policies-based-on-kubescape-controls/kubescape-c-0013-deny-if-container-runs-as-root.md` is a byte for byte copy of the C-0017 doc, so C-0013 has no actual doc page right now

Can send those as a follow up if you want them fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added control identifiers and reference links to two admission policies.
  * Improved policy metadata for easier traceability and navigation.
  * Policy validation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->