### PR TITLE
feat: add C-0263, C-0292 and C-0081

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0271](https://kubescape.io/docs/controls/c-0271/) | Ensure memory limits are set | [kubescape-c-0271-deny-resources-with-memory-limit-not-set](/docs/policies-based-on-kubescape-controls/kubescape-c-0271-deny-resources-with-memory-limit-not-set.md) | [memoryLimitMin](https://kubescape.io/docs/frameworks-and-controls/configuring-controls/#memory_limit_min) |
 | [C-0275](https://kubescape.io/docs/controls/c-0275/) | Minimize the admission of containers wishing to share the host process ID namespace | [kubescape-c-0275-deny-resources-sharing-host-pid-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0275-deny-resources-sharing-host-pid-namespace.md) | not configurable |
 | [C-0276](https://kubescape.io/docs/controls/c-0276/) | Minimize the admission of containers wishing to share the host IPC namespace | [kubescape-c-0276-deny-resources-sharing-host-ipc-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0276-deny-resources-sharing-host-ipc-namespace.md) | not configurable |
+| [C-0081](https://kubescape.io/docs/controls/c-0081/) | CVE-2022-24348 Argo CD directory traversal | [kubescape-c-0081-deny-vulnerable-argocd-versions](/docs/policies-based-on-kubescape-controls/kubescape-c-0081-deny-vulnerable-argocd-versions.md) | not configurable |
+| [C-0263](https://kubescape.io/docs/controls/c-0263/) | Ingress uses TLS | [kubescape-c-0263-deny-ingress-without-tls](/docs/policies-based-on-kubescape-controls/kubescape-c-0263-deny-ingress-without-tls.md) | not configurable |
+| [C-0292](https://kubescape.io/docs/controls/c-0292/) | Nginx Ingress Controller End of Life | [kubescape-c-0292-deny-nginx-ingress-controller-eol](/docs/policies-based-on-kubescape-controls/kubescape-c-0292-deny-nginx-ingress-controller-eol.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0081/policy.yaml
+++ b/controls/C-0081/policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0081-deny-vulnerable-argocd-versions"
+  labels:
+    controlId: "C-0081"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0081/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments"]
+  variables:
+    - expression: |
+        object.kind == 'Deployment'
+          ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
+          : []
+      name: containers
+  validations:
+    # Argo CD fixed CVE-2022-24348 in 2.1.9 and 2.2.4. Vulnerable: any 1.x, any 2.0.x,
+    # 2.1.x below 9 and 2.2.x below 4.
+    # argocd has to be a whole repository segment, otherwise an unrelated image such as
+    # myargocd:v1.8.7 would be denied.
+    # The single-element list is only there to bind the split result to a name, CEL has
+    # no let binding and repeating the split eleven times is unreadable.
+    # size() and matches() must both be checked before int(), because int() raises on a
+    # tag like v2.1.0-rc1 and a raise is an eval error, not a pass.
+    - expression: >
+        variables.containers.all(container,
+          !(container.image.contains('/argocd:v') || container.image.startsWith('argocd:v')) ||
+          [container.image.split('argocd:v')[1].split('.')].all(parts,
+            parts.size() != 3 ||
+            !parts.all(part, part.matches('^[0-9]+$')) ||
+            !(
+              int(parts[0]) == 1 ||
+              (int(parts[0]) == 2 && int(parts[1]) == 0) ||
+              (int(parts[0]) == 2 && int(parts[1]) == 1 && int(parts[2]) < 9) ||
+              (int(parts[0]) == 2 && int(parts[1]) == 2 && int(parts[2]) < 4)
+            )
+          )
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' runs an Argo CD image affected by CVE-2022-24348, fixed in 2.1.9 and 2.2.4. (see more at https://kubescape.io/docs/controls/c-0081/)'

--- a/controls/C-0081/tests.json
+++ b/controls/C-0081/tests.json
@@ -1,0 +1,111 @@
+[
+    {
+        "name": "Deployment not running argocd is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment running argocd v2.1.8 is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.1.8"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v1.8.7 is blocked, every 1.x is vulnerable",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v1.8.7"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.0.5 is blocked, every 2.0.x is vulnerable",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.0.5"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.2.3 is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.2.3"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.1.9 is allowed, that is the fixed release on the 2.1 line",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.1.9"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.2.4 is allowed, that is the fixed release on the 2.2 line",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.2.4"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.3.0 is allowed, it is past the vulnerable range",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.3.0"
+        ]
+    },
+    {
+        "name": "Deployment running argocd v2.1.0-rc1 is allowed, the non numeric guard stops int from raising",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.1.0-rc1"
+        ]
+    },
+    {
+        "name": "Deployment running a two part argocd tag is allowed, the size guard stops the index from raising",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argoproj/argocd:v2.1"
+        ]
+    },
+    {
+        "name": "Deployment running nginx is allowed, the image does not contain argocd:v",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=nginx:1.25"
+        ]
+    },
+    {
+        "name": "Deployment running a bare argocd:v2.1.8 with no registry prefix is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=argocd:v2.1.8"
+        ]
+    },
+    {
+        "name": "Deployment running myargocd:v1.8.7 is allowed, argocd has to be a whole repository segment",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=registry.example.com/team/myargocd:v1.8.7"
+        ]
+    },
+    {
+        "name": "Deployment running a vulnerable argocd image in an init container is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.initContainers=[{\"name\": \"setup\", \"image\": \"argoproj/argocd:v2.1.8\", \"command\": [\"sh\", \"-c\", \"true\"]}]"
+        ]
+    }
+]

--- a/controls/C-0263/policy.yaml
+++ b/controls/C-0263/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0263-deny-ingress-without-tls"
+  labels:
+    controlId: "C-0263"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0263/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["networking.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["ingresses"]
+  validations:
+    # An empty tls list is treated the same as no tls block: it configures no TLS.
+    - expression: "has(object.spec.tls) && object.spec.tls.size() > 0"
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has no TLS configuration, so it serves traffic over plaintext HTTP. (see more at https://kubescape.io/docs/controls/c-0263/)'

--- a/controls/C-0263/tests.json
+++ b/controls/C-0263/tests.json
@@ -1,0 +1,31 @@
+[
+    {
+        "name": "Ingress without a tls block is blocked",
+        "template": "ingress.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Ingress with an empty tls list is blocked, an empty list configures no TLS",
+        "template": "ingress.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.tls=[]"
+        ]
+    },
+    {
+        "name": "Ingress with a tls block is allowed",
+        "template": "ingress.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.tls=[{\"hosts\": [\"test.example.com\"], \"secretName\": \"test-ingress-tls\"}]"
+        ]
+    },
+    {
+        "name": "Ingress with a tls block that only names a secret is allowed",
+        "template": "ingress.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.tls=[{\"secretName\": \"test-ingress-tls\"}]"
+        ]
+    }
+]

--- a/controls/C-0292/policy.yaml
+++ b/controls/C-0292/policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0292-deny-nginx-ingress-controller-eol"
+  labels:
+    controlId: "C-0292"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0292/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","daemonsets","statefulsets"]
+  variables:
+    - expression: |
+        object.kind in ['Deployment','DaemonSet','StatefulSet']
+          ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
+          : []
+      name: containers
+  validations:
+    # Only the community ingress-nginx project reached end of life in March 2026.
+    # NGINX Inc commercial images have their own lifecycle and are deliberately not matched.
+    - expression: >
+        variables.containers.all(container,
+          !container.image.contains('ingress-nginx/controller') &&
+          !container.image.contains('k8s.gcr.io/ingress-nginx') &&
+          !container.image.contains('registry.k8s.io/ingress-nginx')
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' runs the community ingress-nginx controller, which reached end of life in March 2026 and gets no security fixes any more. (see more at https://kubescape.io/docs/controls/c-0292/)'

--- a/controls/C-0292/tests.json
+++ b/controls/C-0292/tests.json
@@ -1,0 +1,76 @@
+[
+    {
+        "name": "Deployment not running an ingress controller is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment running the community controller from registry.k8s.io is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=registry.k8s.io/ingress-nginx/controller:v1.11.2"
+        ]
+    },
+    {
+        "name": "Deployment running an ingress-nginx sidecar image from the old k8s.gcr.io registry is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0"
+        ]
+    },
+    {
+        "name": "Deployment running a mirrored copy of the community controller is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=quay.io/mycompany/ingress-nginx/controller:v1.9.6"
+        ]
+    },
+    {
+        "name": "Deployment running plain nginx is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=nginx:1.25"
+        ]
+    },
+    {
+        "name": "Deployment running the NGINX Inc commercial ingress controller is allowed, it has its own lifecycle",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=nginx/nginx-ingress:3.4.0"
+        ]
+    },
+    {
+        "name": "DaemonSet running the community controller is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=registry.k8s.io/ingress-nginx/controller:v1.11.2"
+        ]
+    },
+    {
+        "name": "StatefulSet running the community controller is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].image=registry.k8s.io/ingress-nginx/controller:v1.11.2"
+        ]
+    },
+    {
+        "name": "DaemonSet not running an ingress controller is allowed",
+        "template": "daemonset.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment running the community controller in an init container is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.initContainers=[{\"name\": \"setup\", \"image\": \"registry.k8s.io/ingress-nginx/controller:v1.11.2\", \"command\": [\"sh\", \"-c\", \"true\"]}]"
+        ]
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -41,3 +41,6 @@ resources:
 - C-0271/policy.yaml
 - C-0275/policy.yaml
 - C-0276/policy.yaml
+- C-0081/policy.yaml
+- C-0263/policy.yaml
+- C-0292/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0081-deny-vulnerable-argocd-versions.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0081-deny-vulnerable-argocd-versions.md
@@ -1,0 +1,25 @@
+# Kubescape C-0081: CVE-2022-24348 Argo CD directory traversal
+
+## Why this policy is required:
+CVE-2022-24348 is a supply chain zero day in Argo CD. A path traversal in the Helm chart handling lets an attacker who can craft a chart read files outside the repository, which leads to privilege escalation and information disclosure. It is fixed in 2.1.9 and 2.2.4.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* Deployment
+
+## What does this policy do:
+This Policy checks every container image in the Deployment, including init containers:
+* If the image names `argocd` as its last repository segment and the tag is a three part numeric version in the vulnerable range, the resource is denied from being deployed in the cluster.
+
+The vulnerable range is any `1.x`, any `2.0.x`, `2.1.x` below `2.1.9`, and `2.2.x` below `2.2.4`.
+
+`argocd` has to be a whole repository segment, so `argoproj/argocd:v2.1.8` and a bare `argocd:v2.1.8` are both matched, while an unrelated image such as `myargocd:v1.8.7` is not.
+
+A tag that is not a plain three part number, for example `v2.1` or `v2.1.0-rc1`, is allowed. The policy cannot tell what such a tag resolves to, and guessing would either raise an evaluation error or block valid images.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0263-deny-ingress-without-tls.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0263-deny-ingress-without-tls.md
@@ -1,0 +1,19 @@
+# Kubescape C-0263: Ingress uses TLS
+
+## Why this policy is required:
+An Ingress with no TLS configuration serves its traffic over plaintext HTTP. Anything on the network path can read or modify the requests and responses, including credentials and session tokens.
+
+## Severity Level: High
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* Ingress
+
+## What does this policy do:
+This Policy checks the Ingress:
+* If `spec.tls` is missing, or present but empty, the Ingress is denied from being deployed in the cluster. An empty `tls` list configures no TLS at all, so it is treated the same as a missing one.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0292-deny-nginx-ingress-controller-eol.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0292-deny-nginx-ingress-controller-eol.md
@@ -1,0 +1,23 @@
+# Kubescape C-0292: Nginx Ingress Controller End of Life
+
+## Why this policy is required:
+The community ingress-nginx project reached End of Life in March 2026. It gets no security patches, bug fixes or feature updates any more, so a cluster still running it stays exposed to anything found from now on. This policy flags workloads running it so the migration to a supported alternative can be planned.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* DaemonSet
+* Deployment
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container image in the workload, including init containers:
+* If the image contains `ingress-nginx/controller`, `k8s.gcr.io/ingress-nginx` or `registry.k8s.io/ingress-nginx`, the resource is denied from being deployed in the cluster.
+
+Only the community ingress-nginx project is matched. NGINX Inc commercial images have their own support lifecycle and are deliberately left alone.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/test-resources/ingress.yaml
+++ b/test-resources/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  labels:
+    admission-policy-test: abc
+spec:
+  rules:
+  - host: test.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 23


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

Three more off the list. C-0263 is `ingress-no-tls` in regolibrary, C-0292 is `detect-nginx-ingress-controller-eol` and C-0081 is `CVE-2022-24348`.

## C-0263, Ingress with no TLS

First control here that matches something other than a workload, so matchConstraints is `networking.k8s.io/v1` ingresses. The check itself is one line, `has(object.spec.tls) && object.spec.tls.size() > 0`. I also added `test-resources/ingress.yaml`, there was no Ingress fixture in the repo yet.

One small difference from the Rego that I want to be upfront about. The Rego does `not ingress.spec.tls`, so an Ingress with `tls: []` passes there. Mine fails it, because an empty list configures no TLS at all. I think failing is the right call but it is a real behaviour change, so say if you disagree and I will drop the size check.

## C-0292, community ingress-nginx EOL

Deployment, DaemonSet and StatefulSet only. The Rego does not cover Pod, Job or CronJob so I did not widen it either, even though most policies in here bind all seven kinds. Widening would change which resources fail.

I kept the three exact substrings from the Rego rather than simplifying to something like `contains('nginx')`. That is on purpose. The comment in the Rego says it only wants the community project, not the NGINX Inc commercial images, which have their own support lifecycle. There is a test for that.

Main containers only, not init or ephemeral, same as the Rego. An ingress controller sitting in an init container is not actually running.

## C-0081, argocd CVE-2022-24348

Deployment only, again like the Rego. This is the fiddly one. It pulls the tag out of the image, splits it on dots, and needs three numeric parts before it can compare anything.

Two guards that are not optional:

* `size() != 3` has to come first, or a tag like `v2.1` makes `parts[2]` raise
* `matches('^[0-9]+$')` has to come before `int()`, or a tag like `v2.1.0-rc1` makes `int()` raise

A raise is not a pass. It is an eval error, and the scanner reports that as skipped, so getting the order wrong would quietly lose the control instead of failing loudly. Both cases have a test.

The `[ ... ].all(parts, ...)` wrapper looks odd, I know. CEL has no let binding, and without it I would be repeating that same long split eleven times in one expression. Wrapping the value in a one element list is the usual way to give it a name. Happy to write it out the long way instead if you would rather not have that pattern in the repo.

## Tests

4 for C-0263, 9 for C-0292, 11 for C-0081. The C-0081 ones sit on both boundaries, 2.1.9 and 2.2.4 pass while 2.1.8 and 2.2.3 fail, plus the two guard tags and a plain nginx image. All 24 pass for me on a local 1.31 cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policies blocking vulnerable Argo CD versions affected by CVE-2022-24348.
  * Added enforcement against Ingress resources without TLS configuration.
  * Added detection of end-of-life community ingress-nginx controllers across supported workload types, while allowing commercial NGINX images.
* **Documentation**
  * Added policy documentation covering scope, severity, configuration, and deployment guidance.
* **Tests**
  * Added comprehensive validation scenarios for vulnerable images, TLS settings, containers, and workload types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->