### PR TITLE
feat: add C-0207, C-0262 and C-0231

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0081](https://kubescape.io/docs/controls/c-0081/) | CVE-2022-24348 Argo CD directory traversal | [kubescape-c-0081-deny-vulnerable-argocd-versions](/docs/policies-based-on-kubescape-controls/kubescape-c-0081-deny-vulnerable-argocd-versions.md) | not configurable |
 | [C-0263](https://kubescape.io/docs/controls/c-0263/) | Ingress uses TLS | [kubescape-c-0263-deny-ingress-without-tls](/docs/policies-based-on-kubescape-controls/kubescape-c-0263-deny-ingress-without-tls.md) | not configurable |
 | [C-0292](https://kubescape.io/docs/controls/c-0292/) | Nginx Ingress Controller End of Life | [kubescape-c-0292-deny-nginx-ingress-controller-eol](/docs/policies-based-on-kubescape-controls/kubescape-c-0292-deny-nginx-ingress-controller-eol.md) | not configurable |
+| [C-0207](https://kubescape.io/docs/controls/c-0207/) | Prefer using secrets as files over secrets as environment variables | [kubescape-c-0207-deny-secrets-as-environment-variables](/docs/policies-based-on-kubescape-controls/kubescape-c-0207-deny-secrets-as-environment-variables.md) | not configurable |
+| [C-0231](https://kubescape.io/docs/controls/c-0231/) | Encrypt traffic to HTTPS load balancers with TLS certificates | [kubescape-c-0231-deny-loadbalancers-without-tls-certificate](/docs/policies-based-on-kubescape-controls/kubescape-c-0231-deny-loadbalancers-without-tls-certificate.md) | not configurable |
+| [C-0262](https://kubescape.io/docs/controls/c-0262/) | Anonymous user has RoleBinding | [kubescape-c-0262-deny-anonymous-access-in-role-bindings](/docs/policies-based-on-kubescape-controls/kubescape-c-0262-deny-anonymous-access-in-role-bindings.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0207/policy.yaml
+++ b/controls/C-0207/policy.yaml
@@ -1,0 +1,46 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0207-deny-secrets-as-environment-variables"
+  labels:
+    controlId: "C-0207"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0207/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : [])
+              : []
+      name: containers
+  validations:
+    # env is optional on a container and valueFrom is optional on an env entry, so both
+    # guards are needed. has(env.valueFrom.secretKeyRef) alone does not guard a missing
+    # valueFrom.
+    - expression: >
+        variables.containers.all(container,
+          !has(container.env) || container.env.all(env,
+            !has(env.valueFrom) || !has(env.valueFrom.secretKeyRef)
+          )
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' injects a Secret into a container through an environment variable, mount it as a file instead. (see more at https://kubescape.io/docs/controls/c-0207/)'

--- a/controls/C-0207/tests.json
+++ b/controls/C-0207/tests.json
@@ -1,0 +1,113 @@
+[
+    {
+        "name": "Pod with no env at all is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with a plain value env is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}]"
+        ]
+    },
+    {
+        "name": "Pod with a secretKeyRef env is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a configMapKeyRef env is allowed, only Secrets are the concern here",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"APP_MODE\", \"valueFrom\": {\"configMapKeyRef\": {\"name\": \"app-config\", \"key\": \"mode\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a fieldRef env is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"POD_NAME\", \"valueFrom\": {\"fieldRef\": {\"fieldPath\": \"metadata.name\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a secretKeyRef env in an init container is blocked",
+        "template": "pod-with-init-container.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "Deployment with no env is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with a secretKeyRef env is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "Deployment with a secretKeyRef env on the second of two env entries is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "ReplicaSet with a secretKeyRef env is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "DaemonSet with a secretKeyRef env is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "StatefulSet with a secretKeyRef env is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "Job with a secretKeyRef env is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "CronJob with a secretKeyRef env is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "CronJob with no env is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    }
+]

--- a/controls/C-0231/policy.yaml
+++ b/controls/C-0231/policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0231-deny-loadbalancers-without-tls-certificate"
+  labels:
+    controlId: "C-0231"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0231/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["services"]
+  validations:
+    # The annotation check leads so that the derived remediation path points at the
+    # annotation, which is where the fix goes, rather than at spec.type.
+    # It is a key PREFIX match over the annotation map, not an exact key lookup, because
+    # the AWS annotation family has suffixed variants.
+    # spec.type and spec.ports are both guarded: the apiserver defaults spec.type before
+    # admission, but a Service read straight from a YAML file during a scan may not carry
+    # it, and a headless or ExternalName Service has no ports.
+    - expression: >
+        (
+          has(object.metadata.annotations) &&
+          object.metadata.annotations.exists(key,
+            key.startsWith('service.beta.kubernetes.io/aws-load-balancer-ssl-cert')
+          )
+        ) ||
+        !has(object.spec.type) || object.spec.type != 'LoadBalancer' ||
+        !has(object.spec.ports) || !object.spec.ports.exists(port, port.port == 443)
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' is a LoadBalancer serving 443 with no AWS SSL certificate annotation, so traffic to the backend is not encrypted. (see more at https://kubescape.io/docs/controls/c-0231/)'

--- a/controls/C-0231/tests.json
+++ b/controls/C-0231/tests.json
@@ -1,0 +1,73 @@
+[
+    {
+        "name": "ClusterIP Service is allowed, this control only cares about LoadBalancers",
+        "template": "service.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "LoadBalancer serving 443 with no annotations at all is blocked",
+        "template": "service.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]"
+        ]
+    },
+    {
+        "name": "LoadBalancer serving 443 with an unrelated annotation is blocked",
+        "template": "service.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]",
+            "metadata.annotations={\"service.beta.kubernetes.io/aws-load-balancer-internal\": \"true\"}"
+        ]
+    },
+    {
+        "name": "LoadBalancer serving 443 with the ssl-cert annotation is allowed",
+        "template": "service.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]",
+            "metadata.annotations={\"service.beta.kubernetes.io/aws-load-balancer-ssl-cert\": \"arn:aws:acm:us-east-1:123456789012:certificate/test\"}"
+        ]
+    },
+    {
+        "name": "LoadBalancer serving 443 with a suffixed ssl-cert annotation is allowed, the match is on the key prefix",
+        "template": "service.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]",
+            "metadata.annotations={\"service.beta.kubernetes.io/aws-load-balancer-ssl-cert-arn\": \"arn:aws:acm:us-east-1:123456789012:certificate/test\"}"
+        ]
+    },
+    {
+        "name": "LoadBalancer serving only 80 is allowed",
+        "template": "service.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 80, \"targetPort\": 8080}]"
+        ]
+    },
+    {
+        "name": "LoadBalancer serving both 80 and 443 with no ssl-cert annotation is blocked",
+        "template": "service.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.type=LoadBalancer",
+            "spec.ports=[{\"name\": \"http\", \"protocol\": \"TCP\", \"port\": 80, \"targetPort\": 8080}, {\"name\": \"https\", \"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]"
+        ]
+    },
+    {
+        "name": "NodePort Service serving 443 is allowed, it is not a LoadBalancer",
+        "template": "service.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.type=NodePort",
+            "spec.ports=[{\"protocol\": \"TCP\", \"port\": 443, \"targetPort\": 8443}]"
+        ]
+    }
+]

--- a/controls/C-0262/policy.yaml
+++ b/controls/C-0262/policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0262-deny-anonymous-access-in-role-bindings"
+  labels:
+    controlId: "C-0262"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0262/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["rolebindings","clusterrolebindings"]
+  validations:
+    # subjects is optional on a binding, so it needs the guard.
+    - expression: >
+        !has(object.subjects) || object.subjects.all(subject,
+          subject.name != 'system:anonymous' &&
+          subject.name != 'system:unauthenticated'
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' grants permissions to anonymous users, so anyone who can reach the API server without credentials gets them. (see more at https://kubescape.io/docs/controls/c-0262/)'

--- a/controls/C-0262/tests.json
+++ b/controls/C-0262/tests.json
@@ -1,0 +1,68 @@
+[
+    {
+        "name": "RoleBinding for an ordinary user is allowed",
+        "template": "role-binding.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "RoleBinding for system:anonymous is blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"User\", \"name\": \"system:anonymous\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding for system:unauthenticated is blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"Group\", \"name\": \"system:unauthenticated\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding for system:authenticated is allowed, only the two anonymous names are the concern",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"Group\", \"name\": \"system:authenticated\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding with system:anonymous as the second of two subjects is blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"User\", \"name\": \"test-user\", \"apiGroup\": \"rbac.authorization.k8s.io\"}, {\"kind\": \"User\", \"name\": \"system:anonymous\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding with no subjects is allowed",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[]"
+        ]
+    },
+    {
+        "name": "ClusterRoleBinding for an ordinary user is allowed",
+        "template": "cluster-role-binding.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "ClusterRoleBinding for system:anonymous is blocked",
+        "template": "cluster-role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"User\", \"name\": \"system:anonymous\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "ClusterRoleBinding for system:unauthenticated is blocked",
+        "template": "cluster-role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"Group\", \"name\": \"system:unauthenticated\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -44,3 +44,6 @@ resources:
 - C-0081/policy.yaml
 - C-0263/policy.yaml
 - C-0292/policy.yaml
+- C-0207/policy.yaml
+- C-0231/policy.yaml
+- C-0262/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0207-deny-secrets-as-environment-variables.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0207-deny-secrets-as-environment-variables.md
@@ -1,0 +1,27 @@
+# Kubescape C-0207: Prefer using secrets as files over secrets as environment variables
+
+## Why this policy is required:
+A Secret injected as an environment variable is readable by anything that can read the process environment. It shows up in `kubectl describe` output, it gets inherited by every child process the container spawns, and it often ends up in crash dumps and logs. Mounting the Secret as a file keeps it out of all of those places and lets you rotate it without restarting the pod.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container in the resource, including init containers and, for a Pod, ephemeral containers:
+* If any environment variable takes its value from `valueFrom.secretKeyRef`, the resource is denied from being deployed in the cluster.
+
+Environment variables sourced from a ConfigMap, from a field reference or from a plain value are not affected.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0231-deny-loadbalancers-without-tls-certificate.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0231-deny-loadbalancers-without-tls-certificate.md
@@ -1,0 +1,23 @@
+# Kubescape C-0231: Encrypt traffic to HTTPS load balancers with TLS certificates
+
+## Why this policy is required:
+A Service of type LoadBalancer that listens on 443 without an SSL certificate configured is not terminating TLS anywhere. Clients think they are talking HTTPS, but the traffic between the load balancer and the backend is plaintext.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* Service
+
+## What does this policy do:
+This Policy checks Services of type `LoadBalancer` that serve port 443:
+* If no annotation key starts with `service.beta.kubernetes.io/aws-load-balancer-ssl-cert`, the Service is denied from being deployed in the cluster.
+
+The match is on the annotation key prefix rather than an exact key, because the AWS load balancer annotation family has suffixed variants.
+
+Services of any other type, and LoadBalancers that do not serve 443, are not affected.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0262-deny-anonymous-access-in-role-bindings.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0262-deny-anonymous-access-in-role-bindings.md
@@ -1,0 +1,22 @@
+# Kubescape C-0262: Anonymous user has RoleBinding
+
+## Why this policy is required:
+A RoleBinding or ClusterRoleBinding that names `system:anonymous` or the `system:unauthenticated` group hands those permissions to anyone who can reach the API server without any credentials at all. There is almost never a good reason for it, and it is an easy thing to leave behind after debugging.
+
+## Severity Level: High
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* ClusterRoleBinding
+* RoleBinding
+
+## What does this policy do:
+This Policy checks every subject in the binding:
+* If a subject is named `system:anonymous` or `system:unauthenticated`, the binding is denied from being deployed in the cluster.
+
+A binding with no subjects at all is allowed, since it grants nothing.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/test-resources/cluster-role-binding.yaml
+++ b/test-resources/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-cluster-role-binding
+  labels:
+    admission-policy-test: abc
+subjects:
+- kind: User
+  name: test-user
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: test-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/test-resources/role-binding.yaml
+++ b/test-resources/role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-role-binding
+  labels:
+    admission-policy-test: abc
+subjects:
+- kind: User
+  name: test-user
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

Three more. C-0207 is `rule-secrets-in-env-var` in regolibrary, C-0262 is `anonymous-access-enabled` and C-0231 is `ensure-https-loadbalancers-encrypted-with-tls-aws`.

Also adds two fixtures, `test-resources/role-binding.yaml` and `test-resources/cluster-role-binding.yaml`, since the repo had Role and ClusterRole but no bindings.

## C-0207, Secrets injected as env vars

First one here with a nested list walk, containers and then env inside each container. Both `has()` guards are load bearing: `env` is optional on a container and `valueFrom` is optional on an env entry, and `has(env.valueFrom.secretKeyRef)` on its own does not cover a missing `valueFrom`.

I walk init containers, and ephemeral containers for Pods, which the Rego does not. That makes the CEL stricter than the Rego. I think it is right, an init container leaking a secret into its environment is the same problem, and it matches what the rest of the library does now. Flagging it because it is a real difference.

Tests cover secretKeyRef, and also configMapKeyRef, fieldRef and a plain value, so it is clear the policy only reacts to Secrets.

## C-0262, anonymous RoleBindings

RoleBinding and ClusterRoleBinding, checking `subjects[*].name` against `system:anonymous` and `system:unauthenticated`. `subjects` is optional so it needs a guard, and a binding with no subjects passes since it grants nothing.

The Rego does `endswith(rolebinding.kind, "Binding")` over whatever is in the input. I did not try to reproduce that on `object.kind`. matchConstraints is the right equivalent here and it is tighter.

There is a test for `system:authenticated` passing, so the two anonymous names do not accidentally grow into a prefix match.

## C-0231, LoadBalancer on 443 with no TLS cert

Only control in the set that iterates map keys instead of list elements, and it is a key prefix match rather than an exact lookup, because the AWS annotation family has suffixed variants. There is a test for a suffixed key.

I put the annotation check first in the disjunction on purpose. It reads slightly odd, but the remediation path we derive comes from the first object field walked, and the finding is really about the missing annotation, not about `spec.type`.

`spec.type` and `spec.ports` are both guarded even though the apiserver defaults `spec.type` before admission. A Service read straight out of a YAML file during a scan does not go through defaulting, and an ExternalName or headless Service has no ports.

One thing worth knowing: this control ships a `filter.rego` narrowing to `spec.type == "LoadBalancer"`. matchConstraints can only filter on kind, so the CEL version evaluates every Service. The verdicts are the same, but the risk score denominator will not be. There is a deliberate ClusterIP test case and a NodePort one so that shows up here rather than surprising someone in a parity run later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kubernetes admission controls to prevent Secrets from being exposed through container environment variables.
  - Added protection requiring AWS TLS certificates for `LoadBalancer` Services serving port 443.
  - Added protection against anonymous or unauthenticated subjects in RoleBindings and ClusterRoleBindings.
  - Registered all three controls for deployment and included coverage for workloads, Services, and RBAC bindings.

- **Documentation**
  - Added usage guidance, policy details, severity information, and remediation recommendations for each control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->