### PR TITLE
add C-0234, C-0295 and C-0212

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0207](https://kubescape.io/docs/controls/c-0207/) | Prefer using secrets as files over secrets as environment variables | [kubescape-c-0207-deny-secrets-as-environment-variables](/docs/policies-based-on-kubescape-controls/kubescape-c-0207-deny-secrets-as-environment-variables.md) | not configurable |
 | [C-0231](https://kubescape.io/docs/controls/c-0231/) | Encrypt traffic to HTTPS load balancers with TLS certificates | [kubescape-c-0231-deny-loadbalancers-without-tls-certificate](/docs/policies-based-on-kubescape-controls/kubescape-c-0231-deny-loadbalancers-without-tls-certificate.md) | not configurable |
 | [C-0262](https://kubescape.io/docs/controls/c-0262/) | Anonymous user has RoleBinding | [kubescape-c-0262-deny-anonymous-access-in-role-bindings](/docs/policies-based-on-kubescape-controls/kubescape-c-0262-deny-anonymous-access-in-role-bindings.md) | not configurable |
+| [C-0234](https://kubescape.io/docs/controls/c-0234/) | Consider external secret storage | [kubescape-c-0234-deny-workloads-without-external-secret-storage](/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md) | not configurable |
+| [C-0295](https://kubescape.io/docs/controls/c-0295/) | Duplicate environment variable | [kubescape-c-0295-deny-duplicate-environment-variables](/docs/policies-based-on-kubescape-controls/kubescape-c-0295-deny-duplicate-environment-variables.md) | not configurable |
+| [C-0212](https://kubescape.io/docs/controls/c-0212/) | The default namespace should not be used | [kubescape-c-0212-deny-resources-in-default-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0212-deny-resources-in-default-namespace.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0212/policy.yaml
+++ b/controls/C-0212/policy.yaml
@@ -1,0 +1,67 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0212-deny-resources-in-default-namespace"
+  labels:
+    controlId: "C-0212"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0212/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods","replicationcontrollers","podtemplates","services","serviceaccounts","secrets","configmaps","endpoints","persistentvolumeclaims"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+    - apiGroups:   ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["roles","rolebindings"]
+    - apiGroups:   ["networking.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["ingresses"]
+    - apiGroups:   ["discovery.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["endpointslices"]
+    # HorizontalPodAutoscaler is served under both v1 and v2 and clusters use both, so
+    # matching only v1 here would quietly miss most of them.
+    - apiGroups:   ["autoscaling"]
+      apiVersions: ["v1","v2"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["horizontalpodautoscalers"]
+    - apiGroups:   ["coordination.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["leases"]
+    - apiGroups:   ["policy"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["poddisruptionbudgets"]
+    - apiGroups:   ["storage.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["csistoragecapacities"]
+  validations:
+    # Every kind this policy matches is namespaced and reaches its namespace through the
+    # same path, so there is no kind dispatch here. This is the one control in the
+    # library where one expression really does cover every matched kind.
+    #
+    # The has() guard is not just defensive. An absent metadata.namespace has to FAIL,
+    # not pass, because it means the default namespace at apply time. At live admission
+    # the apiserver has already defaulted the field before this runs, so the guard is
+    # always true there; it earns its keep when kubescape evaluates the same expression
+    # against a manifest on disk, where nothing has defaulted anything yet.
+    - expression: "has(object.metadata.namespace) && object.metadata.namespace != 'default'"
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' is in the default namespace, which has no RBAC, quota or network boundary of its own. (see more at https://kubescape.io/docs/controls/c-0212/)'

--- a/controls/C-0212/tests.json
+++ b/controls/C-0212/tests.json
@@ -1,0 +1,234 @@
+[
+    {
+        "name": "Pod in the default namespace is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "ReplicationController in the default namespace is blocked",
+        "template": "replicationcontroller.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "PodTemplate in the default namespace is blocked",
+        "template": "podtemplate.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Service in the default namespace is blocked",
+        "template": "service.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "ServiceAccount in the default namespace is blocked",
+        "template": "service-account.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Secret in the default namespace is blocked",
+        "template": "secret.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "ConfigMap in the default namespace is blocked",
+        "template": "configmap.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Endpoints in the default namespace is blocked",
+        "template": "endpoints.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "PersistentVolumeClaim in the default namespace is blocked",
+        "template": "persistentvolumeclaim.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Deployment in the default namespace is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "ReplicaSet in the default namespace is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "DaemonSet in the default namespace is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "StatefulSet in the default namespace is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Job in the default namespace is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "CronJob in the default namespace is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Role in the default namespace is blocked",
+        "template": "role.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "RoleBinding in the default namespace is blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Ingress in the default namespace is blocked",
+        "template": "ingress.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "EndpointSlice in the default namespace is blocked",
+        "template": "endpointslice.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "HorizontalPodAutoscaler in the default namespace is blocked",
+        "template": "horizontalpodautoscaler.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Lease in the default namespace is blocked",
+        "template": "lease.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "PodDisruptionBudget in the default namespace is blocked",
+        "template": "poddisruptionbudget.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "CSIStorageCapacity in the default namespace is blocked",
+        "template": "csistoragecapacity.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.namespace=default"
+        ]
+    },
+    {
+        "name": "Pod outside the default namespace is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "ConfigMap outside the default namespace is allowed",
+        "template": "configmap.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "Role outside the default namespace is allowed",
+        "template": "role.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "Ingress outside the default namespace is allowed",
+        "template": "ingress.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "Lease outside the default namespace is allowed",
+        "template": "lease.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "CSIStorageCapacity outside the default namespace is allowed",
+        "template": "csistoragecapacity.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace"
+        ]
+    }
+]

--- a/controls/C-0234/policy.yaml
+++ b/controls/C-0234/policy.yaml
@@ -1,0 +1,54 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0234-deny-workloads-without-external-secret-storage"
+  labels:
+    controlId: "C-0234"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0234/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    # volumes is optional on every kind, and this control has to treat "no volumes at
+    # all" the same as "volumes, none of them a secrets-store CSI volume", so each
+    # branch defaults to an empty list rather than reading the field unguarded.
+    - expression: |
+        object.kind == 'Pod'
+          ? (has(object.spec.volumes) ? object.spec.volumes : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? (has(object.spec.template.spec.volumes) ? object.spec.template.spec.volumes : [])
+            : object.kind == 'CronJob'
+              ? (has(object.spec.jobTemplate.spec.template.spec.volumes) ? object.spec.jobTemplate.spec.template.spec.volumes : [])
+              : []
+      name: volumes
+  validations:
+    # This control is inverted compared to the rest of the library: it denies on the
+    # ABSENCE of something good rather than the presence of something bad. So the
+    # expression is a bare exists() with no negation, and an empty volumes list fails.
+    #
+    # All three has() calls are needed and they have to be chained. csi is optional on a
+    # volume and volumeAttributes is optional on a csi source, so
+    # has(volume.csi.volumeAttributes.secretProviderClass) on a hostPath volume errors
+    # instead of returning false.
+    - expression: >
+        variables.volumes.exists(volume,
+          has(volume.csi) &&
+          has(volume.csi.volumeAttributes) &&
+          has(volume.csi.volumeAttributes.secretProviderClass)
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' does not read its secrets from an external store through the secrets-store CSI driver. (see more at https://kubescape.io/docs/controls/c-0234/)'

--- a/controls/C-0234/policy.yaml
+++ b/controls/C-0234/policy.yaml
@@ -40,15 +40,24 @@ spec:
     # ABSENCE of something good rather than the presence of something bad. So the
     # expression is a bare exists() with no negation, and an empty volumes list fails.
     #
-    # All three has() calls are needed and they have to be chained. csi is optional on a
-    # volume and volumeAttributes is optional on a csi source, so
+    # The has() calls are chained rather than collapsed. csi is optional on a volume and
+    # volumeAttributes is optional on a csi source, so
     # has(volume.csi.volumeAttributes.secretProviderClass) on a hostPath volume errors
-    # instead of returning false.
+    # instead of returning false. driver is required by the API but a manifest read off
+    # disk during a scan never went through that validation, so it is guarded too.
+    #
+    # The driver name and the non-empty check are both STRICTER than the Rego, which only
+    # asks whether the secretProviderClass key resolves. Without them any CSI driver that
+    # happens to expose an attribute of that name satisfies the control, and so does an
+    # empty value, neither of which is reading secrets from an external store.
     - expression: >
         variables.volumes.exists(volume,
           has(volume.csi) &&
+          has(volume.csi.driver) &&
+          volume.csi.driver == 'secrets-store.csi.k8s.io' &&
           has(volume.csi.volumeAttributes) &&
-          has(volume.csi.volumeAttributes.secretProviderClass)
+          has(volume.csi.volumeAttributes.secretProviderClass) &&
+          volume.csi.volumeAttributes.secretProviderClass != ''
         )
       messageExpression: >
         object.kind + '/' + object.metadata.name + ' does not read its secrets from an external store through the secrets-store CSI driver. (see more at https://kubescape.io/docs/controls/c-0234/)'

--- a/controls/C-0234/tests.json
+++ b/controls/C-0234/tests.json
@@ -1,0 +1,98 @@
+[
+    {
+        "name": "Pod with no volumes at all is blocked",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Pod with volumes but none from the secrets-store CSI driver is blocked",
+        "template": "pod.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Pod with a secretProviderClass CSI volume is allowed",
+        "template": "pod-no-volume.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"secrets-store\", \"csi\": {\"driver\": \"secrets-store.csi.k8s.io\", \"readOnly\": true, \"volumeAttributes\": {\"secretProviderClass\": \"vault-provider\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a secretProviderClass CSI volume alongside an ordinary volume is allowed",
+        "template": "pod-no-volume.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"scratch\", \"emptyDir\": {}}, {\"name\": \"secrets-store\", \"csi\": {\"driver\": \"secrets-store.csi.k8s.io\", \"readOnly\": true, \"volumeAttributes\": {\"secretProviderClass\": \"vault-provider\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a CSI volume that carries no volumeAttributes is blocked, and the chained has() must not error reading it",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"inline-csi\", \"csi\": {\"driver\": \"csi.example.com\"}}]"
+        ]
+    },
+    {
+        "name": "Pod with a CSI volume whose volumeAttributes has no secretProviderClass is blocked",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"inline-csi\", \"csi\": {\"driver\": \"csi.example.com\", \"volumeAttributes\": {\"nodePublishSecretRef\": \"other\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with a non-CSI volume is blocked, and the has(volume.csi) guard must not error on it",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"host\", \"hostPath\": {\"path\": \"/etc\"}}]"
+        ]
+    },
+    {
+        "name": "Deployment with no secrets-store CSI volume is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Deployment with a secretProviderClass CSI volume is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.volumes=[{\"name\": \"test-volume\"}, {\"name\": \"secrets-store\", \"csi\": {\"driver\": \"secrets-store.csi.k8s.io\", \"readOnly\": true, \"volumeAttributes\": {\"secretProviderClass\": \"vault-provider\"}}}]"
+        ]
+    },
+    {
+        "name": "ReplicaSet with no secrets-store CSI volume is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "DaemonSet with no secrets-store CSI volume is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "StatefulSet with no secrets-store CSI volume is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Job with no secrets-store CSI volume is blocked",
+        "template": "job.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "CronJob with no secrets-store CSI volume is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "CronJob with a secretProviderClass CSI volume is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.volumes=[{\"name\": \"test-volume\", \"emptyDir\": {}}, {\"name\": \"secrets-store\", \"csi\": {\"driver\": \"secrets-store.csi.k8s.io\", \"readOnly\": true, \"volumeAttributes\": {\"secretProviderClass\": \"vault-provider\"}}}]"
+        ]
+    }
+]

--- a/controls/C-0234/tests.json
+++ b/controls/C-0234/tests.json
@@ -42,6 +42,22 @@
         ]
     },
     {
+        "name": "Pod with an unrelated CSI driver exposing an attribute named secretProviderClass is blocked, the driver has to be the secrets-store one",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"other-csi\", \"csi\": {\"driver\": \"ebs.csi.aws.com\", \"volumeAttributes\": {\"secretProviderClass\": \"vault-provider\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with an empty secretProviderClass is blocked, the key being present is not enough",
+        "template": "pod-no-volume.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes=[{\"name\": \"secrets-store\", \"csi\": {\"driver\": \"secrets-store.csi.k8s.io\", \"readOnly\": true, \"volumeAttributes\": {\"secretProviderClass\": \"\"}}}]"
+        ]
+    },
+    {
         "name": "Pod with a non-CSI volume is blocked, and the has(volume.csi) guard must not error on it",
         "template": "pod-no-volume.yaml",
         "expected": "fail",

--- a/controls/C-0295/policy.yaml
+++ b/controls/C-0295/policy.yaml
@@ -10,10 +10,13 @@ spec:
   failurePolicy: Fail
   matchConstraints:
     resourceRules:
+    # pods/ephemeralcontainers is the only way an ephemeral container is ever added, so
+    # without it the ephemeralContainers half of the container walk below never sees
+    # anything on a real cluster.
     - apiGroups:   [""]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["pods","replicationcontrollers"]
+      resources:   ["pods","pods/ephemeralcontainers","replicationcontrollers"]
     - apiGroups:   ["apps"]
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]

--- a/controls/C-0295/policy.yaml
+++ b/controls/C-0295/policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0295-deny-duplicate-environment-variables"
+  labels:
+    controlId: "C-0295"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0295/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods","replicationcontrollers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    # ReplicationController is in the pod-template branch on purpose. It is not in the
+    # usual workload list this library walks, but the rule this control comes from covers
+    # it, and leaving it out would drop coverage rather than add any.
+    #
+    # The container walk lives in a variable rather than being copied into each
+    # validation because the check below is the most expensive one in the library. One
+    # walk shared by one validation spends far less of the per-object cost budget than
+    # nine separate expressions would.
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job','ReplicationController']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+  validations:
+    # Finding a duplicate means comparing every entry against every other one, so this is
+    # quadratic in the length of a container's env list however it is written. exists_one
+    # is the cheapest way to say it: a name that appears once matches exactly one entry
+    # (itself), a name that appears twice matches two and fails. filter().size() == 1
+    # says the same thing but builds a throwaway list per entry.
+    #
+    # env is optional on a container, so the !has() guard comes first. A container with
+    # no env has no duplicates.
+    - expression: >
+        variables.containers.all(container,
+          !has(container.env) ||
+          container.env.all(entry,
+            container.env.exists_one(other, other.name == entry.name)
+          )
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a container that defines the same environment variable name twice, and Kubernetes silently keeps the last one. (see more at https://kubescape.io/docs/controls/c-0295/)'

--- a/controls/C-0295/tests.json
+++ b/controls/C-0295/tests.json
@@ -1,0 +1,135 @@
+[
+    {
+        "name": "Pod with no env at all is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with an empty env list is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].env=[]"
+        ]
+    },
+    {
+        "name": "Pod with distinct env names is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"PORT\", \"value\": \"8080\"}]"
+        ]
+    },
+    {
+        "name": "Pod with the same env name twice is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "Pod with the same env name three times is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"warn\"}]"
+        ]
+    },
+    {
+        "name": "Pod where the duplicate entries take their values from different sources is still blocked, the name is what collides",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].env=[{\"name\": \"DB_PASSWORD\", \"value\": \"literal\"}, {\"name\": \"DB_PASSWORD\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"db-secret\", \"key\": \"password\"}}}]"
+        ]
+    },
+    {
+        "name": "Pod with the same env name in two different containers is allowed, the check is per container",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers=[{\"name\": \"first\", \"image\": \"alpine\", \"env\": [{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}]}, {\"name\": \"second\", \"image\": \"alpine\", \"env\": [{\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]}]"
+        ]
+    },
+    {
+        "name": "Pod with a duplicate in the second container is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers=[{\"name\": \"first\", \"image\": \"alpine\", \"env\": [{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}]}, {\"name\": \"second\", \"image\": \"alpine\", \"env\": [{\"name\": \"PORT\", \"value\": \"8080\"}, {\"name\": \"PORT\", \"value\": \"9090\"}]}]"
+        ]
+    },
+    {
+        "name": "Pod with a duplicate in an init container is blocked",
+        "template": "pod-with-init-container.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers.[0].env=[{\"name\": \"SETUP_MODE\", \"value\": \"a\"}, {\"name\": \"SETUP_MODE\", \"value\": \"b\"}]"
+        ]
+    },
+    {
+        "name": "Pod with distinct names in an init container is allowed",
+        "template": "pod-with-init-container.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.initContainers.[0].env=[{\"name\": \"SETUP_MODE\", \"value\": \"a\"}, {\"name\": \"SETUP_TIMEOUT\", \"value\": \"30\"}]"
+        ]
+    },
+    {
+        "name": "Deployment with distinct env names is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"PORT\", \"value\": \"8080\"}]"
+        ]
+    },
+    {
+        "name": "Deployment with a duplicate env name is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "StatefulSet with a duplicate env name is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "Job with a duplicate env name is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "ReplicationController with a duplicate env name is blocked, it is in the rule this control comes from so it is matched here too",
+        "template": "replicationcontroller.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "CronJob with a duplicate env name is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"LOG_LEVEL\", \"value\": \"info\"}]"
+        ]
+    },
+    {
+        "name": "CronJob with distinct env names is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].env=[{\"name\": \"LOG_LEVEL\", \"value\": \"debug\"}, {\"name\": \"PORT\", \"value\": \"8080\"}]"
+        ]
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -47,3 +47,6 @@ resources:
 - C-0207/policy.yaml
 - C-0231/policy.yaml
 - C-0262/policy.yaml
+- C-0234/policy.yaml
+- C-0295/policy.yaml
+- C-0212/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0212-deny-resources-in-default-namespace.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0212-deny-resources-in-default-namespace.md
@@ -1,0 +1,50 @@
+# Kubescape C-0212: The default namespace should not be used
+
+## Why this policy is required:
+The `default` namespace is where everything lands when nobody says otherwise. That makes it the one namespace you cannot write a meaningful RBAC rule about, because it holds unrelated things from unrelated teams. The same goes for ResourceQuota, LimitRange and most NetworkPolicy setups: they are namespace scoped, so a workload sitting in `default` alongside everything else gets no boundary of its own. Putting each application in a namespace made for it is what makes those controls mean anything.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CSIStorageCapacity
+* ConfigMap
+* CronJob
+* DaemonSet
+* Deployment
+* EndpointSlice
+* Endpoints
+* HorizontalPodAutoscaler
+* Ingress
+* Job
+* Lease
+* PersistentVolumeClaim
+* Pod
+* PodDisruptionBudget
+* PodTemplate
+* ReplicaSet
+* ReplicationController
+* Role
+* RoleBinding
+* Secret
+* Service
+* ServiceAccount
+* StatefulSet
+
+## What does this policy do:
+This Policy reads `metadata.namespace` on the resource:
+* If it is `default`, the resource is denied from being deployed in the cluster.
+* If it is missing, the resource is denied too. A manifest with no namespace goes to `default` when it is applied, so leaving it out is the same thing as asking for `default`.
+
+The second case only ever shows up when the manifest is read from a file, for example during a Kubescape scan. At live admission the apiserver has already filled the field in before any policy runs.
+
+## How this relates to C-0061:
+[C-0061](/docs/policies-based-on-kubescape-controls/kubescape-c-0061-deny-workloads-in-default-namespace.md) asks the same question, but only of the seven workload kinds. This one asks it of 23 kinds, so a ConfigMap, a Role or an Ingress in `default` is caught here and not there. They are separate CIS recommendations and both exist upstream, so both exist here. If you bind both, expect a workload in `default` to be reported twice.
+
+## Read this before binding it:
+`default` is where a lot of ordinary cluster bootstrap happens, so binding this one with `validationActions: [Deny]` blocks more than you might expect, including updates to objects that were already living in `default` before you installed the policy. `[Warn]` or `[Audit]` is the safer starting point. The library ships policies only and no bindings, so the enforcement level is yours to pick at install time.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md
@@ -19,9 +19,11 @@ Kubernetes Secrets are only base64 encoded, they sit in etcd, and anything with 
 
 ## What does this policy do:
 This Policy looks at the volumes of the resource, which for a workload means the volumes of its pod template:
-* If none of them is a CSI volume carrying a `csi.volumeAttributes.secretProviderClass`, the resource is denied from being deployed in the cluster.
+* If none of them is a `secrets-store.csi.k8s.io` CSI volume carrying a non-empty `csi.volumeAttributes.secretProviderClass`, the resource is denied from being deployed in the cluster.
 
 A resource with no volumes at all is treated the same as one whose volumes are all ordinary: neither reads secrets from an external store.
+
+The driver name is checked, not just the attribute. Another CSI driver that happens to expose an attribute called `secretProviderClass` is not the secrets-store driver and does not satisfy this control. An empty value does not satisfy it either.
 
 ## Read this before binding it:
 This policy is inverted compared to almost everything else in the library. It does not deny a resource for doing something dangerous, it denies a resource for not doing something good. That means it fires on nearly every workload in a normal cluster, because nearly every workload does not use the secrets-store CSI driver.

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md
@@ -1,0 +1,34 @@
+# Kubescape C-0234: Consider external secret storage
+
+## Why this policy is required:
+Kubernetes Secrets are only base64 encoded, they sit in etcd, and anything with read access to the namespace can usually read them. An external secret store (Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager and so on) keeps the secret material outside the cluster, authenticates every read, records who read what, and lets you rotate a secret without touching the workload. The secrets-store CSI driver is how a workload consumes one of those stores: it mounts the secret as a file at runtime instead of taking it from an in-cluster Secret object.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy looks at the volumes of the resource, which for a workload means the volumes of its pod template:
+* If none of them is a CSI volume carrying a `csi.volumeAttributes.secretProviderClass`, the resource is denied from being deployed in the cluster.
+
+A resource with no volumes at all is treated the same as one whose volumes are all ordinary: neither reads secrets from an external store.
+
+## Read this before binding it:
+This policy is inverted compared to almost everything else in the library. It does not deny a resource for doing something dangerous, it denies a resource for not doing something good. That means it fires on nearly every workload in a normal cluster, because nearly every workload does not use the secrets-store CSI driver.
+
+That is deliberate. CIS phrases this recommendation as "consider", so it is advisory rather than a hard rule, and the Kubescape control it comes from behaves the same way.
+
+If you bind this policy, think carefully before using `validationActions: [Deny]`. `[Warn]` or `[Audit]` is usually what you want: it surfaces the workloads that are still on in-cluster Secrets without blocking every deployment in the cluster on day one. The library ships policies only and no bindings, so this is entirely your call at install time.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0295-deny-duplicate-environment-variables.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0295-deny-duplicate-environment-variables.md
@@ -1,0 +1,33 @@
+# Kubescape C-0295: Duplicate environment variable
+
+## Why this policy is required:
+If a container lists the same environment variable name twice, Kubernetes does not complain. It keeps the last entry and drops the earlier ones, silently. Usually that is a copy-paste mistake or two overlays that both set the same variable. Sometimes it is a security problem, because the entry that gets dropped is the safe one: a hardened default overridden by a leftover debug value, or a `valueFrom.secretKeyRef` shadowed by a plaintext literal that happens to come later in the list.
+
+## Severity Level: Low
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* ReplicationController
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container in the resource, including init containers and ephemeral containers:
+* If any container defines the same `env[].name` more than once, the resource is denied from being deployed in the cluster.
+
+Two different containers in the same pod using the same variable name is fine and is not denied. Each container has its own environment.
+
+## A note on cost:
+Finding a duplicate means comparing every environment variable against every other one in the same container, so the work grows with the square of the list length. That is unavoidable, CEL has no set type to deduplicate with.
+
+Kubernetes gives each policy a fixed runtime cost budget per admission request. On a v1.31 cluster this expression stays inside that budget up to roughly 400 environment variables in a single container, and the cost is per container rather than per pod, so a pod with three containers of 250 variables each is still fine while one container with 450 is not. Past that point the apiserver cancels the evaluation and, with `failurePolicy: Fail`, the request is rejected with a cost error rather than with the message above. Containers anywhere near that many environment variables are rare, but if you have one, that is the behaviour to expect.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/test-resources/csistoragecapacity.yaml
+++ b/test-resources/csistoragecapacity.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIStorageCapacity
+metadata:
+  name: test-csistoragecapacity
+  labels:
+    admission-policy-test: abc
+storageClassName: standard
+capacity: 10Gi

--- a/test-resources/endpoints.yaml
+++ b/test-resources/endpoints.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test-endpoints
+  labels:
+    admission-policy-test: abc
+subsets:
+- addresses:
+  - ip: 10.0.0.1
+  ports:
+  - port: 23
+    protocol: TCP

--- a/test-resources/endpointslice.yaml
+++ b/test-resources/endpointslice.yaml
@@ -1,0 +1,15 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: test-endpointslice
+  labels:
+    admission-policy-test: abc
+    kubernetes.io/service-name: my-service
+addressType: IPv4
+ports:
+- name: http
+  port: 23
+  protocol: TCP
+endpoints:
+- addresses:
+  - "10.0.0.1"

--- a/test-resources/horizontalpodautoscaler.yaml
+++ b/test-resources/horizontalpodautoscaler.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: test-horizontalpodautoscaler
+  labels:
+    admission-policy-test: abc
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: test-deployment
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/test-resources/lease.yaml
+++ b/test-resources/lease.yaml
@@ -1,0 +1,9 @@
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: test-lease
+  labels:
+    admission-policy-test: abc
+spec:
+  holderIdentity: test-holder
+  leaseDurationSeconds: 40

--- a/test-resources/persistentvolumeclaim.yaml
+++ b/test-resources/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-persistentvolumeclaim
+  labels:
+    admission-policy-test: abc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test-resources/poddisruptionbudget.yaml
+++ b/test-resources/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-poddisruptionbudget
+  labels:
+    admission-policy-test: abc
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      label: test-deployment

--- a/test-resources/podtemplate.yaml
+++ b/test-resources/podtemplate.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: test-podtemplate
+  labels:
+    admission-policy-test: abc
+template:
+  metadata:
+    labels:
+      label: test-podtemplate
+  spec:
+    containers:
+    - name: sleep
+      image: alpine
+      command: ["sh"]
+      args: ["-c", "while true; do sleep 1; done"]

--- a/test-resources/replicationcontroller.yaml
+++ b/test-resources/replicationcontroller.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: test-replicationcontroller
+  labels:
+    admission-policy-test: abc
+spec:
+  replicas: 1
+  selector:
+    label: test-replicationcontroller
+  template:
+    metadata:
+      labels:
+        label: test-replicationcontroller
+    spec:
+      containers:
+      - name: sleep
+        image: alpine
+        command: ["sh"]
+        args: ["-c", "while true; do sleep 1; done"]

--- a/test-resources/secret.yaml
+++ b/test-resources/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  labels:
+    admission-policy-test: abc
+type: Opaque
+stringData:
+  password: not-a-real-password


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

Three more. C-0234 is `ensure-external-secrets-storage-is-in-use` in regolibrary, C-0295 is `duplicate-env-var`, and C-0212 is the 17 `*-in-default-namespace` rules rolled into one policy.

Also adds ten fixtures under `test-resources/`. C-0212 matches 23 kinds and the repo only had templates for 13 of them. They are all plain minimal objects, and I dry ran each one against a 1.31 apiserver before writing any tests, so a failing test means the policy and not a bad manifest.

## C-0234, no external secret storage

This one is inverted compared to everything else in the library. It does not deny a workload for doing something bad, it denies it for not doing something good. So the expression is a bare `exists()` with no negation on it, and a workload with no volumes at all fails.

All three `has()` calls are needed and they have to be chained. `csi` is optional on a volume and `volumeAttributes` is optional on a csi source, so `has(volume.csi.volumeAttributes.secretProviderClass)` on a hostPath volume errors instead of returning false. There is a test for each of those shapes.

Worth saying plainly: this fires on nearly every workload in a normal cluster. The Rego does the same, CIS words it as "consider", so it is advisory rather than a hard rule. I put a section in the doc page saying to think about `validationActions: [Warn]` before `[Deny]`. Nothing to decide in the YAML since we do not ship bindings.

Parity note: kubescape derives no remediation path from this one, and I do not think it can. The failing term is a missing collection, there is no element to blame. The Rego emits a `YOUR_VALUE` placeholder fixPath, which we would not copy anyway.

## C-0295, duplicate env var names

Nine deny blocks in the Rego, one expression here off a `variables` block.

**ReplicationController is in this one and it is not in the others.** The Rego's workload set includes it, so leaving it out would drop coverage rather than add any. It is in the kind list in the variable and in matchConstraints. Flagging it because every other container walk in this repo stops at the five apps and batch kinds.

Finding a duplicate means comparing every entry against every other one in the same container, so this is quadratic however you write it, CEL has no set type to deduplicate with. `exists_one` is the cheapest way I found to say it: a name that appears once matches exactly one entry, itself, and a name that appears twice matches two and fails. `filter(...).size() == 1` says the same thing but builds a throwaway list per entry.

I measured it on 1.31 before opening this, since it is easily the most expensive expression in the repo:

- 400 env entries in one container is fine, 450 runs out of the runtime budget and the apiserver cancels with `operation cancelled: actual cost limit exceeded`
- the cost is per container and not per pod. 3 containers of 250 passes, 1 container of 450 does not, so the real ceiling is somewhere around 200k pairwise comparisons added up over the containers
- the policy itself is accepted at creation, so the compile time estimate is nowhere near the limit. Only the runtime budget bites
- with `failurePolicy: Fail` that means going over gets the request rejected with a cost error instead of the message

That is written up in the doc page as well. I did try hoisting `env.map(e, e.name)` out of the inner loop with `cel.bind()` to cut the constant factor, and the apiserver rejects the policy with `undeclared reference to 'names'`, so that is not available to us here.

Parity note: the derived remediation path is `spec.containers[N].env`. The container is pinned, the env index inside it is not, same as C-0207.

## C-0212, default namespace

17 near identical Rego rules, one expression. Every kind this matches is namespaced and reaches its namespace through the same path, so there is no kind dispatch guard. I think it is the only control in the repo where that is true.

Both Rego branches deny, and the one expression reproduces both. A missing `metadata.namespace` fails on purpose, because a manifest with no namespace goes to `default` when you apply it. At live admission the apiserver has already filled that field in before any policy runs, so that half only ever shows up when the object is read straight from a file, which is what a kubescape scan does.

This overlaps C-0061 on the seven workload kinds, with the identical expression. They are separate CIS recommendations and both exist upstream, so both exist here. C-0212 adds 16 more kinds on top, so a ConfigMap or a Role or an Ingress in `default` is caught here and not there. Bind both and a workload in `default` gets reported twice. There is a note about that in the doc page.

Getting 23 kinds and 10 apiGroups right is the fiddly part of this one, so the tests are one fail case per kind. A fail case is what proves matchConstraints actually matched that kind, a pass case would look the same whether the policy matched or not. Six pass cases on top for the non-default path.

Autoscaling is the one place I did not write `apiVersions: ["v1"]`. HorizontalPodAutoscaler is served under both v1 and v2 and clusters use v2, so matching only v1 there would quietly miss most of them.

Same operational warning as C-0234 in the doc page. `default` is where a lot of ordinary bootstrap happens, and binding this as Deny blocks more than you would expect, including updates to objects that were already living there before the policy went in.

Parity note: Rego gives the absent namespace case a fixPath carrying `YOUR_NAMESPACE`. We give a review path on `metadata.namespace` for both cases instead, since we do not invent placeholder values.

## Tests

61 tests, all green on kind v1.31. 15 for C-0234, 17 for C-0295, 29 for C-0212.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added policies preventing duplicate environment-variable names in containers.
  - Added enforcement requiring supported workloads to use external secret storage.
  - Added protection against deploying supported resources to the `default` or unspecified namespace.

- **Documentation**
  - Added policy guidance, severity details, covered resources, and recommended enforcement modes.

- **Tests**
  - Added comprehensive validation coverage and Kubernetes test resources for all three policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->