### PR TITLE
add C-0225 and C-0296

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0234](https://kubescape.io/docs/controls/c-0234/) | Consider external secret storage | [kubescape-c-0234-deny-workloads-without-external-secret-storage](/docs/policies-based-on-kubescape-controls/kubescape-c-0234-deny-workloads-without-external-secret-storage.md) | not configurable |
 | [C-0295](https://kubescape.io/docs/controls/c-0295/) | Duplicate environment variable | [kubescape-c-0295-deny-duplicate-environment-variables](/docs/policies-based-on-kubescape-controls/kubescape-c-0295-deny-duplicate-environment-variables.md) | not configurable |
 | [C-0212](https://kubescape.io/docs/controls/c-0212/) | The default namespace should not be used | [kubescape-c-0212-deny-resources-in-default-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0212-deny-resources-in-default-namespace.md) | not configurable |
+| [C-0225](https://kubescape.io/docs/controls/c-0225/) | Prefer using dedicated EKS Service Accounts | [kubescape-c-0225-deny-default-service-account-rbac-and-automount](/docs/policies-based-on-kubescape-controls/kubescape-c-0225-deny-default-service-account-rbac-and-automount.md) | not configurable |
+| [C-0296](https://kubescape.io/docs/controls/c-0296/) | Mismatching selector | [kubescape-c-0296-deny-workloads-with-mismatching-selector](/docs/policies-based-on-kubescape-controls/kubescape-c-0296-deny-workloads-with-mismatching-selector.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0225/policy.yaml
+++ b/controls/C-0225/policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0225-deny-default-service-account-rbac-and-automount"
+  labels:
+    controlId: "C-0225"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0225/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["serviceaccounts"]
+    - apiGroups:   ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["rolebindings","clusterrolebindings"]
+  validations:
+    # This control is two unrelated rules under one control ID, matching two different
+    # kinds, so each validation carries its own kind guard and they never both apply to
+    # the same object.
+    #
+    # Rule 1: nobody should be granting extra permissions to the `default` ServiceAccount,
+    # which every pod in a namespace gets unless it names another one.
+    #
+    # The bootstrap-label exemption is load bearing. Kubernetes labels its own built-in
+    # bindings with `kubernetes.io/bootstrapping: rbac-defaults`, and several of them bind
+    # the default ServiceAccount on purpose. Without this the policy fires on the cluster's
+    # own bindings everywhere and becomes noise.
+    - expression: >
+        !(object.kind in ['RoleBinding','ClusterRoleBinding']) ||
+        !has(object.subjects) ||
+        (
+          has(object.metadata.labels) &&
+          'kubernetes.io/bootstrapping' in object.metadata.labels &&
+          object.metadata.labels['kubernetes.io/bootstrapping'] == 'rbac-defaults'
+        ) ||
+        object.subjects.all(subject,
+          subject.kind != 'ServiceAccount' || subject.name != 'default'
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' grants permissions to the default ServiceAccount, which every pod in the namespace gets by default. Bind a dedicated ServiceAccount instead. (see more at https://kubescape.io/docs/controls/c-0225/)'
+    # Rule 2: the default ServiceAccount should not hand out its token automatically.
+    #
+    # Unset fails as well as true. Kubernetes mounts the token when the field is absent,
+    # so silence means yes, same as C-0034. Only an explicit false passes.
+    - expression: >
+        object.kind != 'ServiceAccount' ||
+        object.metadata.name != 'default' ||
+        (has(object.automountServiceAccountToken) && object.automountServiceAccountToken == false)
+      messageExpression: >
+        'ServiceAccount/' + object.metadata.name + ' mounts its token into every pod that does not name another ServiceAccount. Set automountServiceAccountToken to false. (see more at https://kubescape.io/docs/controls/c-0225/)'

--- a/controls/C-0225/tests.json
+++ b/controls/C-0225/tests.json
@@ -1,0 +1,125 @@
+[
+    {
+        "name": "RoleBinding with a User subject is allowed",
+        "template": "role-binding.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "RoleBinding with no subjects at all is allowed, it grants nothing",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[]"
+        ]
+    },
+    {
+        "name": "RoleBinding granting the default ServiceAccount is blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding granting a dedicated ServiceAccount is allowed",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"my-app\", \"namespace\": \"default\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding granting the default ServiceAccount alongside other subjects is still blocked",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"my-app\", \"namespace\": \"default\"}, {\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding with a User who happens to be called default is allowed, the subject kind matters",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"User\", \"name\": \"default\", \"apiGroup\": \"rbac.authorization.k8s.io\"}]"
+        ]
+    },
+    {
+        "name": "RoleBinding granting the default ServiceAccount but carrying the bootstrap label is allowed, that is how Kubernetes marks its own bindings",
+        "template": "role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]",
+            "metadata.labels={\"admission-policy-test\": \"abc\", \"kubernetes.io/bootstrapping\": \"rbac-defaults\"}"
+        ]
+    },
+    {
+        "name": "RoleBinding with a bootstrapping label set to something else is still blocked, the exemption is the exact value",
+        "template": "role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]",
+            "metadata.labels={\"admission-policy-test\": \"abc\", \"kubernetes.io/bootstrapping\": \"something-else\"}"
+        ]
+    },
+    {
+        "name": "ClusterRoleBinding granting the default ServiceAccount is blocked",
+        "template": "cluster-role-binding.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]"
+        ]
+    },
+    {
+        "name": "ClusterRoleBinding with a User subject is allowed",
+        "template": "cluster-role-binding.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "ClusterRoleBinding granting the default ServiceAccount but carrying the bootstrap label is allowed",
+        "template": "cluster-role-binding.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "subjects=[{\"kind\": \"ServiceAccount\", \"name\": \"default\", \"namespace\": \"default\"}]",
+            "metadata.labels={\"admission-policy-test\": \"abc\", \"kubernetes.io/bootstrapping\": \"rbac-defaults\"}"
+        ]
+    },
+    {
+        "name": "ServiceAccount that is not the default one is allowed whatever it does with its token",
+        "template": "service-account.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.namespace=test-namespace",
+            "automountServiceAccountToken=true"
+        ]
+    },
+    {
+        "name": "default ServiceAccount with automountServiceAccountToken unset is blocked, Kubernetes mounts when the field is absent",
+        "template": "service-account.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.name=default",
+            "metadata.namespace=test-namespace"
+        ]
+    },
+    {
+        "name": "default ServiceAccount with automountServiceAccountToken true is blocked",
+        "template": "service-account.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "metadata.name=default",
+            "metadata.namespace=test-namespace",
+            "automountServiceAccountToken=true"
+        ]
+    },
+    {
+        "name": "default ServiceAccount with automountServiceAccountToken false is allowed",
+        "template": "service-account.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "metadata.name=default",
+            "metadata.namespace=test-namespace",
+            "automountServiceAccountToken=false"
+        ]
+    }
+]

--- a/controls/C-0296/policy.yaml
+++ b/controls/C-0296/policy.yaml
@@ -1,0 +1,117 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0296-deny-workloads-with-mismatching-selector"
+  labels:
+    controlId: "C-0296"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0296/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["replicationcontrollers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    # Two variables rather than one ternary picking between them by kind. A single
+    # kind-dispatch variable works, but every validation referencing it then carries BOTH
+    # label paths in its AST, and the remediation path derivation reports both: a
+    # Deployment gets told to look at spec.jobTemplate.spec.template.metadata.labels,
+    # which does not exist on it. Splitting them keeps each validation's paths to the
+    # shape its own kinds actually have.
+    #
+    # Each level is guarded separately. has(a.b.c) does not guard a missing a.b, and a
+    # template with no metadata block is legal YAML even though the API would reject it
+    # for a Deployment. A scan reads manifests that never went through that validation.
+    #
+    # Variables are evaluated lazily, so the CronJob validation never touches the first
+    # of these and the workload validations never touch the second.
+    - expression: |
+        has(object.spec.template) && has(object.spec.template.metadata) && has(object.spec.template.metadata.labels)
+          ? object.spec.template.metadata.labels : {}
+      name: templateLabels
+    - expression: |
+        has(object.spec.jobTemplate) && has(object.spec.jobTemplate.spec) &&
+        has(object.spec.jobTemplate.spec.template) && has(object.spec.jobTemplate.spec.template.metadata) &&
+        has(object.spec.jobTemplate.spec.template.metadata.labels)
+          ? object.spec.jobTemplate.spec.template.metadata.labels : {}
+      name: jobTemplateLabels
+  validations:
+    # The subset direction is the easy thing to get backwards: every SELECTOR entry has to
+    # appear in the template labels with the same value. Extra template labels are fine,
+    # that is what makes it a selector.
+    #
+    # On matchExpressions, the operator check has to come first in each clause. Exists and
+    # DoesNotExist carry no `values` field, and reading e.values on one of them raises, so
+    # it is CEL's && short-circuit that keeps those two clauses safe. Do not reorder them.
+    # In and NotIn do read e.values, so those two get a has() guard: the Rego defaults a
+    # missing values to an empty list, which makes In fail to match and NotIn match, and
+    # the guard reproduces exactly that instead of raising.
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
+        !has(object.spec.selector) ||
+        (
+          (
+            !has(object.spec.selector.matchLabels) ||
+            object.spec.selector.matchLabels.all(key,
+              key in variables.templateLabels &&
+              variables.templateLabels[key] == object.spec.selector.matchLabels[key]
+            )
+          ) && (
+            !has(object.spec.selector.matchExpressions) ||
+            object.spec.selector.matchExpressions.all(e,
+              (e.operator == 'In' && e.key in variables.templateLabels && has(e.values) && variables.templateLabels[e.key] in e.values) ||
+              (e.operator == 'NotIn' && (!(e.key in variables.templateLabels) || !has(e.values) || !(variables.templateLabels[e.key] in e.values))) ||
+              (e.operator == 'Exists' && e.key in variables.templateLabels) ||
+              (e.operator == 'DoesNotExist' && !(e.key in variables.templateLabels))
+            )
+          )
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a spec.selector that does not match the labels on its own pod template, so it owns no pods. (see more at https://kubescape.io/docs/controls/c-0296/)'
+    # CronJob keeps its selector under the job template. In practice it is almost never
+    # set, so the guard carries most of the weight here.
+    - expression: >
+        object.kind != 'CronJob' ||
+        !has(object.spec.jobTemplate.spec.selector) ||
+        (
+          (
+            !has(object.spec.jobTemplate.spec.selector.matchLabels) ||
+            object.spec.jobTemplate.spec.selector.matchLabels.all(key,
+              key in variables.jobTemplateLabels &&
+              variables.jobTemplateLabels[key] == object.spec.jobTemplate.spec.selector.matchLabels[key]
+            )
+          ) && (
+            !has(object.spec.jobTemplate.spec.selector.matchExpressions) ||
+            object.spec.jobTemplate.spec.selector.matchExpressions.all(e,
+              (e.operator == 'In' && e.key in variables.jobTemplateLabels && has(e.values) && variables.jobTemplateLabels[e.key] in e.values) ||
+              (e.operator == 'NotIn' && (!(e.key in variables.jobTemplateLabels) || !has(e.values) || !(variables.jobTemplateLabels[e.key] in e.values))) ||
+              (e.operator == 'Exists' && e.key in variables.jobTemplateLabels) ||
+              (e.operator == 'DoesNotExist' && !(e.key in variables.jobTemplateLabels))
+            )
+          )
+        )
+      messageExpression: >
+        'CronJob/' + object.metadata.name + ' has a spec.jobTemplate.spec.selector that does not match the labels on its own pod template, so the Jobs it creates own no pods. (see more at https://kubescape.io/docs/controls/c-0296/)'
+    # ReplicationController is the odd one out: its spec.selector is a plain label map with
+    # no matchLabels wrapper and no matchExpressions at all, so it needs its own expression
+    # rather than sharing either of the two above.
+    - expression: >
+        object.kind != 'ReplicationController' ||
+        !has(object.spec.selector) ||
+        object.spec.selector.all(key,
+          key in variables.templateLabels &&
+          variables.templateLabels[key] == object.spec.selector[key]
+        )
+      messageExpression: >
+        'ReplicationController/' + object.metadata.name + ' has a spec.selector that does not match the labels on its own pod template, so it owns no pods. (see more at https://kubescape.io/docs/controls/c-0296/)'

--- a/controls/C-0296/tests.json
+++ b/controls/C-0296/tests.json
@@ -1,0 +1,81 @@
+[
+    {
+        "name": "Deployment whose selector matches its pod template labels is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with extra labels on the pod template is allowed, the selector only has to be a subset",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.metadata.labels={\"label\": \"test-deployment\", \"tier\": \"web\"}"
+        ]
+    },
+    {
+        "name": "Deployment selecting with an In matchExpression that its template satisfies is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.selector={\"matchExpressions\": [{\"key\": \"label\", \"operator\": \"In\", \"values\": [\"test-deployment\"]}]}"
+        ]
+    },
+    {
+        "name": "Deployment selecting with a NotIn matchExpression that its template satisfies is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.selector={\"matchLabels\": {\"label\": \"test-deployment\"}, \"matchExpressions\": [{\"key\": \"tier\", \"operator\": \"NotIn\", \"values\": [\"db\"]}]}"
+        ]
+    },
+    {
+        "name": "Deployment selecting with an Exists matchExpression that its template satisfies is allowed, and reading the absent values field must not error",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.selector={\"matchExpressions\": [{\"key\": \"label\", \"operator\": \"Exists\"}]}"
+        ]
+    },
+    {
+        "name": "Deployment selecting with a DoesNotExist matchExpression that its template satisfies is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.selector={\"matchLabels\": {\"label\": \"test-deployment\"}, \"matchExpressions\": [{\"key\": \"absent-key\", \"operator\": \"DoesNotExist\"}]}"
+        ]
+    },
+    {
+        "name": "Deployment combining matchLabels and matchExpressions that both hold is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.metadata.labels={\"label\": \"test-deployment\", \"tier\": \"web\"}",
+            "spec.selector={\"matchLabels\": {\"label\": \"test-deployment\"}, \"matchExpressions\": [{\"key\": \"tier\", \"operator\": \"In\", \"values\": [\"web\", \"api\"]}]}"
+        ]
+    },
+    {
+        "name": "ReplicaSet whose selector matches is allowed",
+        "template": "replicaset.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "DaemonSet whose selector matches is allowed",
+        "template": "daemonset.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "StatefulSet whose selector matches is allowed",
+        "template": "statefulset.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Job with no selector of its own is allowed, the controller generates one",
+        "template": "job.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with no selector under its job template is allowed, which is the normal case",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -50,3 +50,5 @@ resources:
 - C-0234/policy.yaml
 - C-0295/policy.yaml
 - C-0212/policy.yaml
+- C-0225/policy.yaml
+- C-0296/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0225-deny-default-service-account-rbac-and-automount.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0225-deny-default-service-account-rbac-and-automount.md
@@ -1,0 +1,35 @@
+# Kubescape C-0225: Prefer using dedicated EKS Service Accounts
+
+## Why this policy is required:
+Every namespace gets a ServiceAccount called `default`, and every pod that does not name one runs as it. So `default` is shared by everything in the namespace, and nothing that runs as it can be told apart from anything else that runs as it.
+
+Two things follow, and this policy checks both. Granting the `default` ServiceAccount extra permissions hands those permissions to every pod in the namespace, including ones added later by someone who has no idea the binding exists. And leaving `automountServiceAccountToken` on means the token is mounted into pods that never asked for an identity at all, so anything that reads the filesystem of a compromised container gets a usable credential.
+
+## Severity Level: High
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* ClusterRoleBinding
+* RoleBinding
+* ServiceAccount
+
+## What does this policy do:
+This policy is two independent checks under one control ID, each matching different kinds.
+
+On a RoleBinding or ClusterRoleBinding:
+* If any subject is a ServiceAccount named `default`, the binding is denied from being deployed in the cluster.
+* Unless the binding carries the label `kubernetes.io/bootstrapping: rbac-defaults`, which is how Kubernetes marks its own built-in bindings. Several of those bind the `default` ServiceAccount on purpose, so without this exemption the policy would fire on the cluster's own RBAC in every namespace.
+
+On a ServiceAccount:
+* If it is named `default` and `automountServiceAccountToken` is not explicitly `false`, it is denied.
+* An absent field counts as a failure, not a pass. Kubernetes mounts the token when nothing says otherwise, so silence means yes. This is the same reasoning as [C-0034](/docs/policies-based-on-kubescape-controls/kubescape-c-0034-deny-resources-with-automount-service-account-token-enabled.md).
+
+A ServiceAccount with any other name is not touched by this policy, whatever it does with its token.
+
+## How to satisfy it:
+Give each workload its own ServiceAccount, bind permissions to that, and set `automountServiceAccountToken: false` on the `default` one in every namespace so nothing picks up a token by accident.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0296-deny-workloads-with-mismatching-selector.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0296-deny-workloads-with-mismatching-selector.md
@@ -1,0 +1,41 @@
+# Kubescape C-0296: Mismatching selector
+
+## Why this policy is required:
+A workload finds the pods it owns through `spec.selector`. If that selector does not match the labels the workload puts on its own pod template, it owns nothing it creates. A Deployment in that state reports zero ready replicas forever while quietly making pods, or worse, the selector matches pods belonging to some other controller and the two fight over the same set.
+
+## Severity Level: Low
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* ReplicaSet
+* ReplicationController
+* StatefulSet
+
+## What does this policy do:
+This policy compares the workload's selector against the labels on its own pod template:
+* If any selector entry is not satisfied by those labels, the workload is denied from being deployed in the cluster.
+
+It is a subset test in one direction only. Every entry in the selector has to be satisfied by the template labels; extra template labels are fine and are the normal case.
+
+Three shapes are handled separately because the three are genuinely different:
+* Deployment, ReplicaSet, DaemonSet, StatefulSet and Job use `spec.selector` with `matchLabels` and `matchExpressions`.
+* CronJob keeps its selector at `spec.jobTemplate.spec.selector`, and in practice almost never sets one.
+* ReplicationController's `spec.selector` is a plain label map with no `matchLabels` wrapper and no `matchExpressions` at all.
+
+All four `matchExpressions` operators are implemented: `In`, `NotIn`, `Exists` and `DoesNotExist`.
+
+## Read this before binding it:
+**This policy has almost nothing to do at live admission, and that is expected.** The API server already refuses to create a workload whose selector does not match its own template labels, with `` `selector` does not match template `labels` ``. It gets there before any admission policy runs, so by the time this policy sees an object the mismatch it looks for has usually already been ruled out. CronJob will not even accept `manualSelector: true` in a job template.
+
+Where it earns its keep is scanning manifests. A file on disk has not been through any of that validation, so a broken selector sits there until someone tries to apply it. Catching it in a scan of your repository or your chart output tells you about it before the cluster does.
+
+Bind it if you want the belt and braces, it costs one cheap expression per workload. Just do not expect it to fire.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

Two more. C-0225 is `ensure-default-service-accounts-has-only-default-roles` plus `automount-default-service-account`, C-0296 is `mismatching-selector`.

## C-0225

Two unrelated rules under one control ID, so two validations each with its own kind guard.

The bootstrap-label exemption is the part that matters. Kubernetes labels its own bindings `kubernetes.io/bootstrapping: rbac-defaults` and some of them bind the default ServiceAccount on purpose, so without it this fires on the cluster's own RBAC everywhere. There is a test for the exemption and one for a different bootstrapping value still being denied, so it stays an exact match.

An absent `automountServiceAccountToken` fails rather than passes. Kubernetes mounts when nothing says otherwise, same as C-0034.

15 tests, green on kind v1.31.

## C-0296

Three selector shapes so three validations: the usual `spec.selector`, CronJob's under `spec.jobTemplate.spec`, and ReplicationController's bare label map with no wrapper. All four `matchExpressions` operators are in.

**All the tests are passes, and I could not write a failing one.** The API server rejects a mismatching selector itself before any policy runs:

```
The Deployment "mismatch-deploy" is invalid: spec.template.metadata.labels:
  Invalid value: ...: `selector` does not match template `labels`
```

Same for all seven kinds. Job is rejected with and without `manualSelector`, CronJob will not take `manualSelector: true` at all. So there is no object the harness can hand this policy that it would be the one to reject.

The passing tests still earn their place, since with `failurePolicy: Fail` a CEL error here would deny every workload in the cluster. They cover all four operators and both of the selector shapes I have fixtures for. The ReplicationController branch has no fixture in this repo yet, so I covered it in the engine run below rather than adding one here and colliding with #117.

I tested the deny half through the kubescape CEL engine against manifest fixtures, 27 cases across all four operators and all three shapes, all correct.

So this one does nothing at admission and I would rather say that than hide it. It is useful when scanning manifests, because a file on disk never went through that validation. Tell me if you would rather not ship a policy that is redundant in a cluster and I will drop it.

12 tests, green on kind v1.31.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admission controls to prevent unauthorized use of the default ServiceAccount and unintended token automounting.
  * Added validation to detect mismatches between workload selectors and pod-template labels across supported Kubernetes workloads.
  * Registered both policies for deployment and included them in the policy library.

* **Documentation**
  * Added guidance, severity details, configuration information, and usage instructions for both controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->