### PR TITLE
add C-0202, C-0203 and C-0204

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0212](https://kubescape.io/docs/controls/c-0212/) | The default namespace should not be used | [kubescape-c-0212-deny-resources-in-default-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0212-deny-resources-in-default-namespace.md) | not configurable |
 | [C-0225](https://kubescape.io/docs/controls/c-0225/) | Prefer using dedicated EKS Service Accounts | [kubescape-c-0225-deny-default-service-account-rbac-and-automount](/docs/policies-based-on-kubescape-controls/kubescape-c-0225-deny-default-service-account-rbac-and-automount.md) | not configurable |
 | [C-0296](https://kubescape.io/docs/controls/c-0296/) | Mismatching selector | [kubescape-c-0296-deny-workloads-with-mismatching-selector](/docs/policies-based-on-kubescape-controls/kubescape-c-0296-deny-workloads-with-mismatching-selector.md) | not configurable |
+| [C-0202](https://kubescape.io/docs/controls/c-0202/) | Minimize the admission of Windows HostProcess Containers | [kubescape-c-0202-deny-windows-hostprocess-containers](/docs/policies-based-on-kubescape-controls/kubescape-c-0202-deny-windows-hostprocess-containers.md) | not configurable |
+| [C-0203](https://kubescape.io/docs/controls/c-0203/) | Minimize the admission of HostPath volumes | [kubescape-c-0203-deny-hostpath-volumes](/docs/policies-based-on-kubescape-controls/kubescape-c-0203-deny-hostpath-volumes.md) | not configurable |
+| [C-0204](https://kubescape.io/docs/controls/c-0204/) | Minimize the admission of containers which use HostPorts | [kubescape-c-0204-deny-containers-using-host-ports](/docs/policies-based-on-kubescape-controls/kubescape-c-0204-deny-containers-using-host-ports.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0202/policy.yaml
+++ b/controls/C-0202/policy.yaml
@@ -1,0 +1,68 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0202-deny-windows-hostprocess-containers"
+  labels:
+    controlId: "C-0202"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0202/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec
+              : {}
+      name: podSpec
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+  validations:
+    # Deliberately two validations rather than one `&&`. hostProcess can be set on the pod
+    # security context or on a single container, and the two are different things to fix.
+    # Joined with && the whole thing is one expression, and a container-level violation
+    # still derives the pod-level field as its remediation path, which would tell someone
+    # to edit spec.securityContext when the problem is in a container.
+    #
+    # Every level is guarded on its own. has(a.b.c) does not guard a missing a.b, and
+    # windowsOptions with only runAsUserName in it is a normal thing to write.
+    - expression: >
+        !has(variables.podSpec.securityContext) ||
+        !has(variables.podSpec.securityContext.windowsOptions) ||
+        !has(variables.podSpec.securityContext.windowsOptions.hostProcess) ||
+        variables.podSpec.securityContext.windowsOptions.hostProcess != true
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' sets windowsOptions.hostProcess on the pod security context, so its Windows containers run as host processes. (see more at https://kubescape.io/docs/controls/c-0202/)'
+    - expression: >
+        variables.containers.all(container,
+          !has(container.securityContext) ||
+          !has(container.securityContext.windowsOptions) ||
+          !has(container.securityContext.windowsOptions.hostProcess) ||
+          container.securityContext.windowsOptions.hostProcess != true
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a container that sets windowsOptions.hostProcess, so it runs as a host process on the Windows node. (see more at https://kubescape.io/docs/controls/c-0202/)'

--- a/controls/C-0202/tests.json
+++ b/controls/C-0202/tests.json
@@ -1,0 +1,124 @@
+[
+    {
+        "name": "Pod with no security context is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with windowsOptions but no hostProcess is allowed, this is the guard that matters",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.securityContext.windowsOptions.runAsUserName=ContainerUser"
+        ]
+    },
+    {
+        "name": "Pod with hostProcess set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.securityContext.windowsOptions.hostProcess=false"
+        ]
+    },
+    {
+        "name": "Pod with hostProcess on the pod security context is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.securityContext.windowsOptions.hostProcess=true",
+            "spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Pod with hostProcess on a container is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Pod with hostProcess on an init container is blocked, the api server makes every container carry it",
+        "template": "pod-with-init-container.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Deployment with no security context is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with hostProcess on the pod security context is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Deployment with hostProcess on a container is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "ReplicaSet with hostProcess on a container is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "DaemonSet with hostProcess on a container is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "StatefulSet with hostProcess on a container is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "Job with hostProcess on a container is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.template.spec.hostNetwork=true"
+        ]
+    },
+    {
+        "name": "CronJob with no security context is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with hostProcess on a container is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].securityContext.windowsOptions.hostProcess=true",
+            "spec.jobTemplate.spec.template.spec.hostNetwork=true"
+        ]
+    }
+]

--- a/controls/C-0203/policy.yaml
+++ b/controls/C-0203/policy.yaml
@@ -1,0 +1,49 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0203-deny-hostpath-volumes"
+  labels:
+    controlId: "C-0203"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0203/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  # Written per kind against object rather than through a podSpec variable, which is the
+  # shape C-0048 already uses for the same field. A variable would work, but the path
+  # derivation in the scanner walks object-rooted expressions, so this way a failure can
+  # point at spec.volumes[2] instead of at nothing. Volumes are pod level and ephemeral
+  # containers cannot add any, so there is no init or ephemeral dimension here and no
+  # reason to reach for a variable.
+  validations:
+    - expression: >
+        object.kind != 'Pod' ||
+        !has(object.spec.volumes) ||
+        object.spec.volumes.all(volume, !has(volume.hostPath))
+      messageExpression: >
+        'Pod/' + object.metadata.name + ' has a hostPath volume, which mounts a path from the node into the pod. (see more at https://kubescape.io/docs/controls/c-0203/)'
+    - expression: >
+        ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) ||
+        !has(object.spec.template.spec.volumes) ||
+        object.spec.template.spec.volumes.all(volume, !has(volume.hostPath))
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a hostPath volume, which mounts a path from the node into its pods. (see more at https://kubescape.io/docs/controls/c-0203/)'
+    - expression: >
+        object.kind != 'CronJob' ||
+        !has(object.spec.jobTemplate.spec.template.spec.volumes) ||
+        object.spec.jobTemplate.spec.template.spec.volumes.all(volume, !has(volume.hostPath))
+      messageExpression: >
+        'CronJob/' + object.metadata.name + ' has a hostPath volume, which mounts a path from the node into the pods it creates. (see more at https://kubescape.io/docs/controls/c-0203/)'

--- a/controls/C-0203/tests.json
+++ b/controls/C-0203/tests.json
@@ -1,0 +1,87 @@
+[
+    {
+        "name": "Pod with no volumes at all is allowed",
+        "template": "pod-no-volume.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with volumes but none of them hostPath is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with a hostPath volume is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes.[0].hostPath.path=/var"
+        ]
+    },
+    {
+        "name": "Pod with a hostPath volume mounted readOnly is still blocked, this is what separates it from C-0045",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.volumes.[0].hostPath.path=/var",
+            "spec.containers.[0].volumeMounts.[0].readOnly=true"
+        ]
+    },
+    {
+        "name": "Deployment with volumes but none of them hostPath is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with a hostPath volume is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes.[0].hostPath.path=/var"
+        ]
+    },
+    {
+        "name": "ReplicaSet with a hostPath volume is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes=[{\"name\": \"host\", \"hostPath\": {\"path\": \"/var\"}}]"
+        ]
+    },
+    {
+        "name": "DaemonSet with a hostPath volume is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes=[{\"name\": \"host\", \"hostPath\": {\"path\": \"/var\"}}]"
+        ]
+    },
+    {
+        "name": "StatefulSet with a hostPath volume is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes=[{\"name\": \"host\", \"hostPath\": {\"path\": \"/var\"}}]"
+        ]
+    },
+    {
+        "name": "Job with a hostPath volume is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.volumes=[{\"name\": \"host\", \"hostPath\": {\"path\": \"/var\"}}]"
+        ]
+    },
+    {
+        "name": "CronJob with an emptyDir volume is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with a hostPath volume is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.volumes.[0]={\"name\": \"test-volume\", \"hostPath\": {\"path\": \"/var\"}}"
+        ]
+    }
+]

--- a/controls/C-0204/policy.yaml
+++ b/controls/C-0204/policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0204-deny-containers-using-host-ports"
+  labels:
+    controlId: "C-0204"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0204/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+  validations:
+    # hostPort == 0 passes on purpose. HostPort is a plain int32 in the Go type, not a
+    # pointer, so a manifest that carries it as an explicit zero means the same thing as
+    # leaving it out: no port is claimed on the node. Failing on 0 would block a manifest
+    # that reserves nothing. C-0044 checks the same field with has() alone and does fail
+    # on an explicit zero, and it also walks only spec.containers, so the two policies do
+    # not always agree.
+    - expression: >
+        variables.containers.all(container,
+          !has(container.ports) ||
+          container.ports.all(port, !has(port.hostPort) || port.hostPort == 0)
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a container claiming a hostPort, which binds a port on the node itself. (see more at https://kubescape.io/docs/controls/c-0204/)'

--- a/controls/C-0204/tests.json
+++ b/controls/C-0204/tests.json
@@ -1,0 +1,94 @@
+[
+    {
+        "name": "Pod with a container port but no host port is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with no ports at all is allowed",
+        "template": "pod-with-init-container.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with hostPort set to 0 is allowed, zero claims nothing on the node",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].ports.[0].hostPort=0"
+        ]
+    },
+    {
+        "name": "Pod with a real hostPort is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].ports.[0].hostPort=8080"
+        ]
+    },
+    {
+        "name": "Pod with a hostPort only on an init container is blocked, C-0044 does not look there",
+        "template": "pod-with-init-container.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers.[0].ports=[{\"containerPort\": 9000, \"hostPort\": 9000}]"
+        ]
+    },
+    {
+        "name": "Deployment with a container port but no host port is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with a real hostPort is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports.[0].hostPort=8080"
+        ]
+    },
+    {
+        "name": "ReplicaSet with a real hostPort is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports=[{\"containerPort\": 8086, \"hostPort\": 8080}]"
+        ]
+    },
+    {
+        "name": "DaemonSet with a real hostPort is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports=[{\"containerPort\": 8086, \"hostPort\": 8080}]"
+        ]
+    },
+    {
+        "name": "StatefulSet with a real hostPort is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports=[{\"containerPort\": 8086, \"hostPort\": 8080}]"
+        ]
+    },
+    {
+        "name": "Job with a real hostPort is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].ports=[{\"containerPort\": 8086, \"hostPort\": 8080}]"
+        ]
+    },
+    {
+        "name": "CronJob with a container port but no host port is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with a real hostPort is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].ports.[0].hostPort=8080"
+        ]
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -52,3 +52,6 @@ resources:
 - C-0212/policy.yaml
 - C-0225/policy.yaml
 - C-0296/policy.yaml
+- C-0202/policy.yaml
+- C-0203/policy.yaml
+- C-0204/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0202-deny-windows-hostprocess-containers.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0202-deny-windows-hostprocess-containers.md
@@ -1,0 +1,37 @@
+# Kubescape C-0202: Minimize the admission of Windows HostProcess Containers
+
+## Why this policy is required:
+A Windows container making use of the `hostProcess` flag can interact with the underlying Windows cluster node. As per the Kubernetes documentation, this provides "privileged access" to the Windows node.
+
+Where Windows containers are used inside a Kubernetes cluster, there should be at least one admission control policy which does not permit `hostProcess` Windows containers.
+
+If you need to run Windows containers which require `hostProcess`, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: High
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks `securityContext.windowsOptions.hostProcess` in two places, and denies the resource if either one is `set to true`:
+* On the pod security context, where it becomes the default for every container in the pod.
+* On any individual container, including init containers and ephemeral containers.
+
+A `windowsOptions` block that sets something else, such as `runAsUserName`, and leaves `hostProcess` out is allowed. So is `hostProcess` explicitly `set to false`.
+
+These are written as two separate checks rather than one. `hostProcess` on the pod security context and `hostProcess` on a container are different things to fix, and keeping them apart means the reported field is the one you actually have to edit.
+
+## A note on what a live cluster will let you send:
+The API server has its own rules about `hostProcess` that run before any admission policy does. A pod that sets it must also set `hostNetwork: true`, and if any container is a HostProcess container then all of them have to be. So the mixed case, one HostProcess container next to a normal one, never reaches this policy on a real cluster. It can still appear in a manifest scanned from a file, which is why the container check walks every container rather than stopping at the first.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0203-deny-hostpath-volumes.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0203-deny-hostpath-volumes.md
@@ -1,0 +1,35 @@
+# Kubescape C-0203: Minimize the admission of HostPath volumes
+
+## Why this policy is required:
+A container which mounts a `hostPath` volume as part of its specification will have access to the filesystem of the underlying cluster node. The use of `hostPath` volumes may allow containers access to privileged areas of the node filesystem.
+
+There should be at least one admission control policy defined which does not permit containers to mount `hostPath` volumes.
+
+If you need to run containers which require `hostPath` volumes, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks the volume list in the pod spec of the resource:
+* If no volume declares a `hostPath` source, the resource is allowed. If any volume does, the resource is denied from being deployed in the cluster.
+
+A resource with no volumes at all is allowed, and so is one whose volumes are all of some other type such as `emptyDir` or a projected secret.
+
+## How this relates to the other hostPath policies:
+* **C-0048** checks the same field in the same way. If you have both bound, they will deny the same resources.
+* **C-0045** is narrower. It only denies a `hostPath` volume that is *mounted without* `readOnly: true`. A read only hostPath mount passes C-0045 and is still denied here, since this control is about the volume existing at all rather than about how it is mounted.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0204-deny-containers-using-host-ports.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0204-deny-containers-using-host-ports.md
@@ -1,0 +1,38 @@
+# Kubescape C-0204: Minimize the admission of containers which use HostPorts
+
+## Why this policy is required:
+Host ports connect containers directly to the host's network. This can bypass controls such as network policy.
+
+There should be at least one admission control policy defined which does not permit containers which require the use of HostPorts.
+
+If you need to run containers which require HostPorts, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container in the resource, including init containers and ephemeral containers:
+* If no container declares a port with a `hostPort`, the resource is allowed. If any container does, the resource is denied from being deployed in the cluster.
+
+A container with no `ports` at all is allowed, and so is one that declares only `containerPort`.
+
+`hostPort: 0` is treated as allowed. `HostPort` is a plain `int32` in the Kubernetes API type rather than a pointer, so a manifest carrying an explicit zero means the same thing as leaving the field out: no port is claimed on the node.
+
+## How this relates to C-0044:
+C-0044 checks the same field, and for an ordinary workload the two agree. They differ in two places:
+* This policy walks init containers and ephemeral containers as well as `containers`. C-0044 only looks at `containers`, so a `hostPort` on an init container passes it and is denied here.
+* C-0044 denies on the presence of the field, so it also denies an explicit `hostPort: 0`. This policy allows that.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

Three more from the Pod Security Admission family, converted the same way as C-0198 to C-0201: each control becomes the workload check its CIS item is really about, not the namespace label the shared Rego rule looks at.

One correction up front. I went in assuming all three were new checks. Two are not, and I only caught it by reading the bundle instead of the control descriptions. **C-0203 is the same check as C-0048**, same field and same shape. **C-0204 overlaps C-0044.** I still wrote both, because the loader keys on the `controlId` label and a control with no policy directory of its own cannot report at all. C-0013 already overlaps C-0016 and C-0198 the same way. The doc pages spell out the real relationships so nobody has to rediscover this.

### C-0202, Windows hostProcess

The only genuinely new one. Checks `windowsOptions.hostProcess` on the pod security context and on every container, init and ephemeral included.

Two validations rather than one `&&`. Joined together, a container-level violation still reports the pod-level field as the thing to fix, which sends you to the wrong place.

What surprised me is that the API server gets there first. `hostProcess: true` requires `hostNetwork: true`, and if any container is a HostProcess container then all of them must be. So a mixed pod never reaches this policy on a live cluster, only in a scanned file. Every failing test carries `hostNetwork: true` for that reason.

### C-0203, hostPath volumes

Denies any `hostPath` volume outright. Written per kind against `object` rather than through a variable, matching C-0048, because the scan-side path derivation walks object-rooted expressions, so a failure can point at `spec.volumes[2].hostPath` instead of at nothing.

Worth separating from C-0045, which only denies a hostPath mounted *without* `readOnly: true`. There is a test for a read only hostPath mount: C-0045 passes it, this denies it.

### C-0204, hostPorts

Two deliberate differences from C-0044. It walks init and ephemeral containers, so a hostPort on an init container is denied here and passes C-0044. And `hostPort: 0` is allowed, since `HostPort` is a plain `int32` rather than a pointer and an explicit zero means the same as leaving it out. Tests for both.

### Testing

40 cases, all green. I checked every fixture against the API server before writing the test, which is how the hostProcess rules turned up. No new files in `test-resources/`, the existing templates cover all of it.

Small thing I hit: `scripts/change-yaml-field.py` cannot create a list that does not already exist, so where I needed a new `ports` or `volumes` list I passed the whole list as one JSON value. Happy to send a fix for the script separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admission policies that block Windows HostProcess containers, `hostPath` volumes, and nonzero container host ports.
  * Policies cover Pods and supported workload resources, including init and ephemeral containers where applicable.
* **Documentation**
  * Added policy guidance, severity details, supported resources, and implementation references for controls C-0202, C-0203, and C-0204.
* **Tests**
  * Added conformance coverage for allowed and rejected configurations across supported Kubernetes resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->