### PR TITLE
fix C-0020 denying everything with a hostPath when cloudProvider is not configured

### DIFF
--- a/configuration/basic-control-configuration.yaml
+++ b/configuration/basic-control-configuration.yaml
@@ -3,6 +3,9 @@ kind: ControlConfiguration
 metadata:
   name: basic-control-configuration
 settings:
+  # Set this to eks, aks or gke to make C-0020 check that cloud's credential
+  # paths. An empty value means "unknown cloud", so C-0020 checks none of them.
+  cloudProvider: ""
   cpuLimitMax: 5
   cpuLimitMin: 0.5
   cpuRequestMax: 5

--- a/controls/C-0020/policy.yaml
+++ b/controls/C-0020/policy.yaml
@@ -25,12 +25,20 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobs","cronjobs"]
+  variables:
+    # cloudProvider is optional in the ControlConfiguration, and reading a key
+    # that is not there is an eval error, which failurePolicy: Fail turns into a
+    # denial. Falling back to an empty string keeps that a pass instead: no
+    # provider matches, so none of the credential path lists are checked.
+    - name: cloudProvider
+      expression: >
+        has(params.settings.cloudProvider) ? params.settings.cloudProvider : ''
   validations:
     - expression: >
         object.kind != 'Pod' || !has(object.spec.volumes) || object.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
-          (params.settings.cloudProvider != 'eks' ||
+          (variables.cloudProvider != 'eks' ||
           ["/.aws/","/.aws/config/","/.aws/credentials/"].all(unsafePath,
           (
             (
@@ -42,7 +50,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'aks' ||
+          (variables.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
             (
@@ -54,7 +62,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'gke' ||
+          (variables.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (
             (
@@ -72,7 +80,7 @@ spec:
         ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job'].all(kind, object.kind != kind) || !has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
-          (params.settings.cloudProvider != 'eks' ||
+          (variables.cloudProvider != 'eks' ||
           ["/.aws/","/.aws/config/","/.aws/credentials/"].all(unsafePath,
           (
             (
@@ -84,7 +92,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'aks' ||
+          (variables.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
             (
@@ -96,7 +104,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'gke' ||
+          (variables.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (
             (
@@ -114,7 +122,7 @@ spec:
         object.kind != 'CronJob' || !has(object.spec.jobTemplate.spec.template.spec.volumes) || object.spec.jobTemplate.spec.template.spec.volumes.all(vol,
         !has(vol.hostPath) || !has(vol.hostPath.path) ||
         (
-          (params.settings.cloudProvider != 'eks' ||
+          (variables.cloudProvider != 'eks' ||
           ["/.aws/","/.aws/config/","/.aws/credentials/"].all(unsafePath,
           (
             (
@@ -126,7 +134,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'aks' ||
+          (variables.cloudProvider != 'aks' ||
           ["/etc/","/etc/kubernetes/","/etc/kubernetes/azure.json","/.azure/","/.azure/credentials/","/etc/kubernetes/azure.json"].all(unsafePath,
           (
             (
@@ -138,7 +146,7 @@ spec:
               unsafePath != vol.hostPath.path
             )))) &&
 
-          (params.settings.cloudProvider != 'gke' ||
+          (variables.cloudProvider != 'gke' ||
           ["/.config/gcloud/","/.config/","/gcloud/","/.config/gcloud/application_default_credentials.json","/gcloud/application_default_credentials.json"].all(unsafePath,
           (
             (

--- a/controls/C-0020/tests.json
+++ b/controls/C-0020/tests.json
@@ -61,5 +61,24 @@
         "field_change_list": [
             "spec.template.spec.volumes.[0].hostPath.path=/etc/kubernetes/azure.json"
         ]
+    },
+
+    {
+        "name": "Cloud Provider is not configured and Pod having volume with hostPath \"/etc/kubernetes\" is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "param_template": "empty-control-configuration.yaml",
+        "field_change_list": [
+            "spec.volumes.[0].hostPath.path=/etc/kubernetes"
+        ]
+    },
+    {
+        "name": "Cloud Provider is not configured and Deployment having volume with hostPath \"/etc/kubernetes\" is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "param_template": "empty-control-configuration.yaml",
+        "field_change_list": [
+            "spec.template.spec.volumes.[0].hostPath.path=/etc/kubernetes"
+        ]
     }
 ]

--- a/scripts/run-control-tests.py
+++ b/scripts/run-control-tests.py
@@ -56,6 +56,7 @@ try:
         field_change_list = test['field_change_list'] if 'field_change_list' in test else []
         expected = test['expected']
         binding_template = test['binding_template'] if 'binding_template' in test else 'policy-binding.yaml'
+        param_template = test['param_template'] if 'param_template' in test else 'default-control-configuration.yaml'
 
         print('-'*120)
         print('Running test: ' + name)
@@ -85,7 +86,7 @@ try:
         with tempfile.NamedTemporaryFile() as temp_file:
             param_file_name = temp_file.name
         param_file_change_list = ['metadata.name=' + policy_name + '-params']
-        subprocess.check_call([python_executable, os.path.join(SCRIPTS_DIR, 'change-yaml-field.py'), '-i', os.path.join(TEST_RESOURCES_DIR, 'default-control-configuration.yaml'), '-o', param_file_name] + param_file_change_list)
+        subprocess.check_call([python_executable, os.path.join(SCRIPTS_DIR, 'change-yaml-field.py'), '-i', os.path.join(TEST_RESOURCES_DIR, param_template), '-o', param_file_name] + param_file_change_list)
         print('Generated parameter file: ' + param_file_name)
 
 

--- a/test-resources/empty-control-configuration.yaml
+++ b/test-resources/empty-control-configuration.yaml
@@ -1,0 +1,9 @@
+# A ControlConfiguration with an empty settings block. Every key in the schema is
+# optional, so this is a valid thing for a user to apply, and a policy that reads
+# a setting has to cope with that key not being there instead of erroring out.
+# Point a test at this with "param_template" to check that.
+apiVersion: "kubescape.io/v1"
+kind: ControlConfiguration
+metadata:
+  name: placeholder
+settings: {}


### PR DESCRIPTION
Fixes #116.

`cloudProvider` is missing from `configuration/basic-control-configuration.yaml`, and C-0020 is the only policy that reads it. Reading a key that is not there is an eval error, and every policy here is `failurePolicy: Fail`, so the apiserver denies the request instead of skipping the policy. CEL short circuits, so the key only gets read once a hostPath volume actually matches one of the sensitive paths. The control looks completely healthy until the moment it is supposed to catch something.

I did both fixes from the issue, because they cover different holes.

Added `cloudProvider: ""` to the shipped config. With an empty value every clause short circuits to true, so nothing gets denied, and anyone actually on AKS or EKS sets it and the control works properly.

Added a `cloudProvider` variable on the policy that falls back to `''` when the key is absent, and pointed the 9 reads at it. The config change fixes the default path, but a user who writes their own ControlConfiguration and leaves the key out would still walk into the same deny. This covers that one.

On the test side, there was no way to run a control against a params file missing a key, which is why CI never saw this. `run-control-tests.py` now takes an optional `param_template` per test, same shape as the `binding_template` option that was already there, defaulting to the current file so no other control changes. Added `test-resources/empty-control-configuration.yaml` and two C-0020 cases that point at it.

Checked on kind v1.31. All 10 C-0020 cases pass, and the two new ones both fail against the policy as it is today, so they do catch the bug rather than just sitting there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cloud provider configuration for EKS, AKS, and GKE environments.
  * Cloud-specific credential path checks are skipped when no provider is configured.

* **Bug Fixes**
  * Prevented validation errors when cloud provider settings are missing.
  * Improved handling of Pod, workload, and CronJob credential-path checks.

* **Tests**
  * Added coverage for missing cloud provider configuration and Kubernetes host paths.
  * Test cases can now use custom parameter templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->