### PR TITLE
add C-0193, C-0194, C-0195 and C-0197

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ kubectl -n policy-example run nginx --image=nginx --restart=Never
 | [C-0202](https://kubescape.io/docs/controls/c-0202/) | Minimize the admission of Windows HostProcess Containers | [kubescape-c-0202-deny-windows-hostprocess-containers](/docs/policies-based-on-kubescape-controls/kubescape-c-0202-deny-windows-hostprocess-containers.md) | not configurable |
 | [C-0203](https://kubescape.io/docs/controls/c-0203/) | Minimize the admission of HostPath volumes | [kubescape-c-0203-deny-hostpath-volumes](/docs/policies-based-on-kubescape-controls/kubescape-c-0203-deny-hostpath-volumes.md) | not configurable |
 | [C-0204](https://kubescape.io/docs/controls/c-0204/) | Minimize the admission of containers which use HostPorts | [kubescape-c-0204-deny-containers-using-host-ports](/docs/policies-based-on-kubescape-controls/kubescape-c-0204-deny-containers-using-host-ports.md) | not configurable |
+| [C-0193](https://kubescape.io/docs/controls/c-0193/) | Minimize the admission of privileged containers | [kubescape-c-0193-deny-privileged-containers](/docs/policies-based-on-kubescape-controls/kubescape-c-0193-deny-privileged-containers.md) | not configurable |
+| [C-0194](https://kubescape.io/docs/controls/c-0194/) | Minimize the admission of containers wishing to share the host process ID namespace | [kubescape-c-0194-deny-resources-sharing-host-pid-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0194-deny-resources-sharing-host-pid-namespace.md) | not configurable |
+| [C-0195](https://kubescape.io/docs/controls/c-0195/) | Minimize the admission of containers wishing to share the host IPC namespace | [kubescape-c-0195-deny-resources-sharing-host-ipc-namespace](/docs/policies-based-on-kubescape-controls/kubescape-c-0195-deny-resources-sharing-host-ipc-namespace.md) | not configurable |
+| [C-0197](https://kubescape.io/docs/controls/c-0197/) | Minimize the admission of containers with allowPrivilegeEscalation | [kubescape-c-0197-deny-containers-with-allow-privilege-escalation](/docs/policies-based-on-kubescape-controls/kubescape-c-0197-deny-containers-with-allow-privilege-escalation.md) | not configurable |
 
 ## Testing Policies
 

--- a/controls/C-0193/policy.yaml
+++ b/controls/C-0193/policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0193-deny-privileged-containers"
+  labels:
+    controlId: "C-0193"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0193/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+  validations:
+    # securityContext.privileged only. C-0057 checks this same field and also fails a
+    # container adding SYS_ADMIN or ALL, so a workload that only adds a capability is a
+    # C-0057 violation and not a C-0193 one. Keeping this narrow is the point: the CIS
+    # item behind C-0193 is about the privileged flag.
+    - expression: >
+        variables.containers.all(container,
+          !has(container.securityContext) ||
+          !has(container.securityContext.privileged) ||
+          container.securityContext.privileged != true
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a privileged container, which gets almost all of the host kernel capabilities. (see more at https://kubescape.io/docs/controls/c-0193/)'

--- a/controls/C-0193/tests.json
+++ b/controls/C-0193/tests.json
@@ -1,0 +1,97 @@
+[
+    {
+        "name": "Pod without securityContext is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with privileged set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.privileged=false"
+        ]
+    },
+    {
+        "name": "Pod with privileged set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Pod with a privileged initContainer is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.initContainers=[{\"name\":\"init\",\"image\":\"alpine\",\"command\":[\"sh\"],\"securityContext\":{\"privileged\":true}}]"
+        ]
+    },
+    {
+        "name": "Pod adding the SYS_ADMIN capability without the privileged flag is allowed, added capabilities are C-0057's job",
+        "template": "pod-for-list-items.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.capabilities.add.[0]=SYS_ADMIN"
+        ]
+    },
+    {
+        "name": "Deployment without securityContext is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with privileged set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "ReplicaSet with privileged set to true is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "DaemonSet with privileged set to true is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "StatefulSet with privileged set to true is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "Job with privileged set to true is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    },
+    {
+        "name": "CronJob without securityContext is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with privileged set to true is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].securityContext.privileged=true"
+        ]
+    }
+]

--- a/controls/C-0194/policy.yaml
+++ b/controls/C-0194/policy.yaml
@@ -1,0 +1,40 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0194-deny-resources-sharing-host-pid-namespace"
+  labels:
+    controlId: "C-0194"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0194/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec
+              : {}
+      name: podSpec
+  validations:
+    # Same check as C-0275, which is the same CIS item under a different control ID.
+    # Keep the two expressions identical if either one changes.
+    - expression: "!has(variables.podSpec.hostPID) || variables.podSpec.hostPID == false"
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has hostPID enabled, so its containers share the host process ID namespace. (see more at https://kubescape.io/docs/controls/c-0194/)'

--- a/controls/C-0194/tests.json
+++ b/controls/C-0194/tests.json
@@ -1,0 +1,105 @@
+[
+    {
+        "name": "Pod without hostPID is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with hostPID set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.hostPID=false"
+        ]
+    },
+    {
+        "name": "Pod with hostPID set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "Pod with only hostIPC set to true is allowed, this control does not cover hostIPC",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "Deployment without hostPID is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with hostPID set to false is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.hostPID=false"
+        ]
+    },
+    {
+        "name": "Deployment with hostPID set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "ReplicaSet with hostPID set to true is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "DaemonSet with hostPID set to true is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "StatefulSet with hostPID set to true is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "Job with hostPID set to true is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "CronJob without hostPID is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with hostPID set to false is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.hostPID=false"
+        ]
+    },
+    {
+        "name": "CronJob with hostPID set to true is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.hostPID=true"
+        ]
+    }
+]

--- a/controls/C-0195/policy.yaml
+++ b/controls/C-0195/policy.yaml
@@ -1,0 +1,40 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0195-deny-resources-sharing-host-ipc-namespace"
+  labels:
+    controlId: "C-0195"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0195/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec
+              : {}
+      name: podSpec
+  validations:
+    # Same check as C-0276, which is the same CIS item under a different control ID.
+    # Keep the two expressions identical if either one changes.
+    - expression: "!has(variables.podSpec.hostIPC) || variables.podSpec.hostIPC == false"
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has hostIPC enabled, so its containers share the host IPC namespace. (see more at https://kubescape.io/docs/controls/c-0195/)'

--- a/controls/C-0195/tests.json
+++ b/controls/C-0195/tests.json
@@ -1,0 +1,105 @@
+[
+    {
+        "name": "Pod without hostIPC is allowed",
+        "template": "pod.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Pod with hostIPC set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.hostIPC=false"
+        ]
+    },
+    {
+        "name": "Pod with hostIPC set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "Pod with only hostPID set to true is allowed, this control does not cover hostPID",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.hostPID=true"
+        ]
+    },
+    {
+        "name": "Deployment without hostIPC is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "Deployment with hostIPC set to false is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=false"
+        ]
+    },
+    {
+        "name": "Deployment with hostIPC set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "ReplicaSet with hostIPC set to true is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "DaemonSet with hostIPC set to true is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "StatefulSet with hostIPC set to true is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "Job with hostIPC set to true is blocked",
+        "template": "job.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.hostIPC=true"
+        ]
+    },
+    {
+        "name": "CronJob without hostIPC is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass"
+    },
+    {
+        "name": "CronJob with hostIPC set to false is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.hostIPC=false"
+        ]
+    },
+    {
+        "name": "CronJob with hostIPC set to true is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.hostIPC=true"
+        ]
+    }
+]

--- a/controls/C-0197/policy.yaml
+++ b/controls/C-0197/policy.yaml
@@ -1,0 +1,46 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "kubescape-c-0197-deny-containers-with-allow-privilege-escalation"
+  labels:
+    controlId: "C-0197"
+  annotations:
+    controlUrl: "https://kubescape.io/docs/controls/c-0197/"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pods", "pods/ephemeralcontainers"]
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments","replicasets","daemonsets","statefulsets"]
+    - apiGroups:   ["batch"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["jobs","cronjobs"]
+  variables:
+    - expression: |
+        object.kind == 'Pod'
+          ? object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+          : object.kind in ['Deployment','ReplicaSet','DaemonSet','StatefulSet','Job']
+            ? object.spec.template.spec.containers + (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : []) + (has(object.spec.template.spec.ephemeralContainers) ? object.spec.template.spec.ephemeralContainers : [])
+            : object.kind == 'CronJob'
+              ? object.spec.jobTemplate.spec.template.spec.containers + (has(object.spec.jobTemplate.spec.template.spec.initContainers) ? object.spec.jobTemplate.spec.template.spec.initContainers : []) + (has(object.spec.jobTemplate.spec.template.spec.ephemeralContainers) ? object.spec.jobTemplate.spec.template.spec.ephemeralContainers : [])
+              : []
+      name: containers
+  validations:
+    # Absent counts as a violation, not a pass. allowPrivilegeEscalation defaults to true
+    # for a container that is not running as privileged with no capabilities added, so
+    # leaving it unset is the risk the control is about. Same reading as C-0016.
+    - expression: >
+        variables.containers.all(container,
+          has(container.securityContext) &&
+          has(container.securityContext.allowPrivilegeEscalation) &&
+          container.securityContext.allowPrivilegeEscalation == false
+        )
+      messageExpression: >
+        object.kind + '/' + object.metadata.name + ' has a container with allowPrivilegeEscalation not set to false, so a process in it can gain more privileges than its parent. (see more at https://kubescape.io/docs/controls/c-0197/)'

--- a/controls/C-0197/tests.json
+++ b/controls/C-0197/tests.json
@@ -1,0 +1,98 @@
+[
+    {
+        "name": "Pod with allowPrivilegeEscalation set to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false"
+        ]
+    },
+    {
+        "name": "Pod with allowPrivilegeEscalation set to true is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=true"
+        ]
+    },
+    {
+        "name": "Pod without securityContext is blocked, the field defaults to true",
+        "template": "pod.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Pod with a securityContext that does not mention allowPrivilegeEscalation is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.runAsUser=1000"
+        ]
+    },
+    {
+        "name": "Pod with a good container and an initContainer missing the field is blocked",
+        "template": "pod.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
+            "spec.initContainers=[{\"name\":\"init\",\"image\":\"alpine\",\"command\":[\"sh\"]}]"
+        ]
+    },
+    {
+        "name": "Pod with both the container and the initContainer setting it to false is allowed",
+        "template": "pod.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.containers.[0].securityContext.allowPrivilegeEscalation=false",
+            "spec.initContainers=[{\"name\":\"init\",\"image\":\"alpine\",\"command\":[\"sh\"],\"securityContext\":{\"allowPrivilegeEscalation\":false}}]"
+        ]
+    },
+    {
+        "name": "Deployment with allowPrivilegeEscalation set to false is allowed",
+        "template": "deployment.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.allowPrivilegeEscalation=false"
+        ]
+    },
+    {
+        "name": "Deployment with allowPrivilegeEscalation set to true is blocked",
+        "template": "deployment.yaml",
+        "expected": "fail",
+        "field_change_list": [
+            "spec.template.spec.containers.[0].securityContext.allowPrivilegeEscalation=true"
+        ]
+    },
+    {
+        "name": "ReplicaSet without allowPrivilegeEscalation is blocked",
+        "template": "replicaset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "DaemonSet without allowPrivilegeEscalation is blocked",
+        "template": "daemonset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "StatefulSet without allowPrivilegeEscalation is blocked",
+        "template": "statefulset.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "Job without allowPrivilegeEscalation is blocked",
+        "template": "job.yaml",
+        "expected": "fail"
+    },
+    {
+        "name": "CronJob with allowPrivilegeEscalation set to false is allowed",
+        "template": "cronjob.yaml",
+        "expected": "pass",
+        "field_change_list": [
+            "spec.jobTemplate.spec.template.spec.containers.[0].securityContext.allowPrivilegeEscalation=false"
+        ]
+    },
+    {
+        "name": "CronJob without allowPrivilegeEscalation is blocked",
+        "template": "cronjob.yaml",
+        "expected": "fail"
+    }
+]

--- a/controls/kustomization.yaml
+++ b/controls/kustomization.yaml
@@ -55,3 +55,7 @@ resources:
 - C-0202/policy.yaml
 - C-0203/policy.yaml
 - C-0204/policy.yaml
+- C-0193/policy.yaml
+- C-0194/policy.yaml
+- C-0195/policy.yaml
+- C-0197/policy.yaml

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0193-deny-privileged-containers.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0193-deny-privileged-containers.md
@@ -1,0 +1,32 @@
+# Kubescape C-0193: Minimize the admission of privileged containers
+
+## Why this policy is required:
+A privileged container gets almost all of the capabilities of the host, and it also loses the limits a container runtime normally applies to devices. That makes a container escape much easier, so there should be at least one admission control policy defined which does not permit privileged containers.
+
+If you need to run privileged containers, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: High
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container in the resource, including init containers and ephemeral containers:
+* If no container has `securityContext.privileged` set to `true`, the resource is allowed. If any container does, the resource is denied from being deployed in the cluster.
+
+A container with no `securityContext` at all is allowed, and so is one with `privileged: false`.
+
+## How this relates to C-0057:
+C-0057 checks the same `privileged` field, so anything denied here is denied there too. C-0057 goes further and also denies a container that adds the `SYS_ADMIN` or `ALL` capability, which this policy allows. So a workload that adds capabilities without setting `privileged` is a C-0057 violation and not a C-0193 one.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0194-deny-resources-sharing-host-pid-namespace.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0194-deny-resources-sharing-host-pid-namespace.md
@@ -1,0 +1,32 @@
+# Kubescape C-0194: Minimize the admission of containers wishing to share the host process ID namespace
+
+## Why this policy is required:
+A container running in the host's PID namespace can inspect processes running outside the container. If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container. There should be at least one admission control policy defined which does not permit containers to share the host PID namespace.
+
+If you need to run containers which require `hostPID`, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks the pod spec of the resource:
+* If `hostPID` is `not set` or `set to false`, the resource is allowed. If it is `set to true`, the resource is denied from being deployed in the cluster.
+
+The `hostIPC` field is covered separately by C-0195.
+
+## How this relates to C-0275 and C-0038:
+C-0275 is the same check on the same field, from a different framework. The two policies deny the same resources, and they exist separately because the library keys a policy to exactly one control ID. C-0038 checks `hostPID` and `hostIPC` together, so it denies a superset of what this one does.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0195-deny-resources-sharing-host-ipc-namespace.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0195-deny-resources-sharing-host-ipc-namespace.md
@@ -1,0 +1,32 @@
+# Kubescape C-0195: Minimize the admission of containers wishing to share the host IPC namespace
+
+## Why this policy is required:
+A container running in the host's IPC namespace can use shared memory to interact with processes outside the container. There should be at least one admission control policy defined which does not permit containers to share the host IPC namespace.
+
+If you need to run containers which require `hostIPC`, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks the pod spec of the resource:
+* If `hostIPC` is `not set` or `set to false`, the resource is allowed. If it is `set to true`, the resource is denied from being deployed in the cluster.
+
+The `hostPID` field is covered separately by C-0194.
+
+## How this relates to C-0276 and C-0038:
+C-0276 is the same check on the same field, from a different framework. The two policies deny the same resources, and they exist separately because the library keys a policy to exactly one control ID. C-0038 checks `hostPID` and `hostIPC` together, so it denies a superset of what this one does.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)

--- a/docs/policies-based-on-kubescape-controls/kubescape-c-0197-deny-containers-with-allow-privilege-escalation.md
+++ b/docs/policies-based-on-kubescape-controls/kubescape-c-0197-deny-containers-with-allow-privilege-escalation.md
@@ -1,0 +1,32 @@
+# Kubescape C-0197: Minimize the admission of containers with allowPrivilegeEscalation
+
+## Why this policy is required:
+A container with `allowPrivilegeEscalation` left on can run a process that gains more privileges than its parent, usually through a setuid binary. There should be at least one admission control policy defined which does not permit containers to allow privilege escalation.
+
+If you need to run containers which require privilege escalation, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+
+## Severity Level: Medium
+
+## Configuration Parameters:
+* Not Configurable
+
+## Resources this policy could be applied to:
+* CronJob
+* DaemonSet
+* Deployment
+* Job
+* Pod
+* ReplicaSet
+* StatefulSet
+
+## What does this policy do:
+This Policy checks every container in the resource, including init containers and ephemeral containers:
+* If every container sets `securityContext.allowPrivilegeEscalation` to `false`, the resource is allowed. Otherwise the resource is denied from being deployed in the cluster.
+
+Leaving the field out is a denial, not a pass. Kubernetes defaults it to `true` for a container that is not privileged and adds no capabilities, so an unset field is the risk the control is about. A container with no `securityContext`, or with a `securityContext` that does not mention the field, is denied for the same reason.
+
+## How this relates to C-0016:
+C-0016 checks the same field with the same reading, over the same container list. The two policies deny the same resources. They exist separately because they come from different frameworks and the library keys a policy to exactly one control ID, so C-0197 needs its own policy to be reported at all.
+
+## Implementing this policy in the Cluster:
+[Refer here for using the policy in the cluster](https://github.com/kubescape/cel-admission-library#using-the-library)


### PR DESCRIPTION
Part of #99, and kubescape/kubescape#2002.

This is the last of the Pod Security Admission controls, and three of the four are checks the library already has. That is on purpose. A policy carries one `controlId` label, so a control with no policy of its own is not reported at all, no matter how many other policies happen to look at the same field. C-0013 already overlaps C-0016 and C-0198 for the same reason.

**C-0193, privileged containers.** The one that is not a copy. C-0057 checks the same `privileged` field but also denies a container adding `SYS_ADMIN` or `ALL`, so it denies strictly more. I kept this one to the privileged flag only, which is what its CIS item is about. There is a test for exactly that difference: same fixture and same field change as C-0057's SYS_ADMIN case, expecting pass here instead of fail.

**C-0197, allowPrivilegeEscalation.** Same check as C-0016, same reading, including that leaving the field out is a denial and not a pass. Kubernetes defaults it to true, so unset is the risk the control is about.

**C-0194 and C-0195, hostPID and hostIPC.** Copies of C-0275 and C-0276. I copied the expressions rather than rewriting them, and left a comment on each saying to keep the pair identical if either one changes.

All four use the container list or podSpec variable shape that is already standard in the bundle, so init and ephemeral containers are covered where that makes sense.

Tests are 55 cases across the four, run against a real apiserver on kind v1.31, all passing. The hostPID and hostIPC suites are the C-0275 and C-0276 suites unchanged, so the two pairs are tested the same way.

Each docs page says which existing policy overlaps and how, rather than leaving someone to work that out from a scan report with two findings on one field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admission policies blocking privileged containers and unsafe privilege escalation settings.
  * Added protections against workloads sharing host PID or IPC namespaces.
  * Policies cover Pods and common workload resources, including init and ephemeral containers.

* **Documentation**
  * Added policy documentation, configuration details, severity information, and implementation guidance.
  * Updated the policy library with four new Kubescape controls.

* **Tests**
  * Added comprehensive coverage for allowed and denied configurations across supported Kubernetes resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->