### PR TITLE
fix: correct SYS_ADM typo in shared test fixtures

### DIFF
--- a/test-resources/deployment-with-common-label-1.yaml
+++ b/test-resources/deployment-with-common-label-1.yaml
@@ -23,4 +23,4 @@ spec:
         securityContext:
           capabilities:
             add:
-            - SYS_ADM
+            - SYS_ADMIN

--- a/test-resources/deployment-with-common-label-2.yaml
+++ b/test-resources/deployment-with-common-label-2.yaml
@@ -23,4 +23,4 @@ spec:
         securityContext:
           capabilities:
             add:
-            - SYS_ADM
+            - SYS_ADMIN

--- a/test-resources/pod-capabilities.yaml
+++ b/test-resources/pod-capabilities.yaml
@@ -13,5 +13,5 @@ spec:
     securityContext:
       capabilities:
         add:
-        - SYS_ADM
+        - SYS_ADMIN
         - NET_RAW


### PR DESCRIPTION
Fixes #108.

PR #104 corrected the SYS_ADM typo in the C-0057 policy, but the invalid string was left behind in the shared test fixtures. This renames it to SYS_ADMIN in the three files listed in the issue.

I left test-resources/pod-for-list-items.yaml and test-resources/deployment-for-list-items.yaml alone on purpose, even though they contain the same string. pod-for-list-items.yaml is used by the C-0046 test "Pod having containers with capabilities set but not from insecure list", which expects a pass. SYS_ADMIN is in the insecureCapabilities list in configuration/basic-control-configuration.yaml, so renaming it there would make that test fail. The typo is load bearing in that file.

For the three files changed here, nothing that reads them matches on capability names. C-0077 only looks at labels, C-0200 only checks whether any capability was added at all, and the C-0046 case on pod-capabilities.yaml already fails on NET_RAW so it stays failing either way.

I could not run the control test suite locally since it needs a live cluster, so I am relying on CI for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected container and pod capability configuration to use the valid `SYS_ADMIN` capability.
  * Updated deployment test configurations for consistent capability handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->